### PR TITLE
Check for java home mismatch.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ apply(plugin = "com.osacky.doctor")
 
 configure<DoctorExtension> {
   disallowMultipleDaemons = false
+  ensureJavaHomeMatches = !System.getenv().containsKey("CI")
   GCWarningThreshold = 0.01f
   enableTestCaching = false
   downloadSpeedWarningThreshold = 2.0f

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
@@ -4,7 +4,15 @@ open class DoctorExtension {
     /**
      * Throw an exception when multiple Gradle Daemons are running.
      */
-    var disallowMultipleDaemons = true
+    var disallowMultipleDaemons = false
+    /**
+     * Ensure that we are using JAVA_HOME to build with this Gradle.
+     */
+    var ensureJavaHomeMatches = true
+    /**
+     * Ensure we have JAVA_HOME set.
+     */
+    var ensureJavaHomeIsSet = true
     /**
      * Show a message if the download speed is less than this.
      */

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -26,18 +26,20 @@ class DoctorPlugin : Plugin<Project> {
 
         val pillBoxPrinter = PillBoxPrinter(target.logger)
         val daemonChecker = BuildDaemonChecker(extension, DaemonCheck(), pillBoxPrinter)
+        val javaHomeCheck = JavaHomeCheck(extension, pillBoxPrinter)
         val garbagePrinter = GarbagePrinter(SystemClock(), DirtyBeanCollector(), extension)
         val operations = BuildOperations(target.gradle)
         val javaAnnotationTime = JavaAnnotationTime(operations, extension)
         val downloadSpeedMeasurer = DownloadSpeedMeasurer(operations, extension)
         val buildCacheConnectionMeasurer = BuildCacheConnectionMeasurer(operations, extension)
-        val list = listOf(daemonChecker, garbagePrinter, javaAnnotationTime, downloadSpeedMeasurer, buildCacheConnectionMeasurer)
+        val list = listOf(daemonChecker, javaHomeCheck, garbagePrinter, javaAnnotationTime, downloadSpeedMeasurer, buildCacheConnectionMeasurer)
         garbagePrinter.onStart()
         javaAnnotationTime.onStart()
         downloadSpeedMeasurer.onStart()
         buildCacheConnectionMeasurer.onStart()
         target.afterEvaluate {
             daemonChecker.onStart()
+            javaHomeCheck.onStart()
         }
 
         target.gradle.buildFinished {

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -30,11 +30,10 @@ class JavaHomeCheck(
     private val environmentJavaHome = System.getenv("JAVA_HOME")
     private val gradleJavaHome = Jvm.current().javaHome
 
-    private fun isGradleUsingJavaHome() : Boolean {
+    private fun isGradleUsingJavaHome(): Boolean {
         if (environmentJavaHome != null && gradleJavaHome.startsWith(environmentJavaHome)) {
             return true
         }
         return false
     }
-
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -1,0 +1,40 @@
+package com.osacky.doctor
+
+import com.osacky.doctor.internal.Finish
+import com.osacky.doctor.internal.PillBoxPrinter
+import org.gradle.api.GradleException
+import org.gradle.internal.jvm.Jvm
+
+class JavaHomeCheck(
+    private val extension: DoctorExtension,
+    private val pillBoxPrinter: PillBoxPrinter
+) : BuildStartFinishListener {
+    override fun onStart() {
+        if (extension.ensureJavaHomeIsSet && environmentJavaHome == null) {
+            throw GradleException(pillBoxPrinter.createPill("JAVA_HOME must be set."))
+        }
+        if (extension.ensureJavaHomeMatches && !isGradleUsingJavaHome()) {
+            throw GradleException(pillBoxPrinter.createPill("""
+                |Gradle is not using JAVA_HOME.
+                |This can slow down your build significantly when switching from command line to the terminal.
+                |To fix: Project Structure -> JDK Location.
+                |Set this to your JAVA_HOME.
+            """.trimMargin()))
+        }
+    }
+
+    override fun onFinish(): Finish {
+        return Finish.None
+    }
+
+    private val environmentJavaHome = System.getenv("JAVA_HOME")
+    private val gradleJavaHome = Jvm.current().javaHome
+
+    private fun isGradleUsingJavaHome() : Boolean {
+        if (environmentJavaHome != null && gradleJavaHome.startsWith(environmentJavaHome)) {
+            return true
+        }
+        return false
+    }
+
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
@@ -33,6 +33,7 @@ class PluginIntegrationTest constructor(private val version: String) {
                     |}
                     |doctor {
                     |  disallowMultipleDaemons = false
+                    |  ensureJavaHomeMatches = !System.getenv().containsKey("CI")
                     |}
                 """.trimMargin("|")
         )
@@ -52,6 +53,7 @@ class PluginIntegrationTest constructor(private val version: String) {
                     |}
                     |doctor {
                     |  disallowMultipleDaemons = false
+                    |  ensureJavaHomeMatches = !System.getenv().containsKey("CI")
                     |}
                 """.trimMargin("|")
         )
@@ -73,6 +75,7 @@ class PluginIntegrationTest constructor(private val version: String) {
                     |}
                     |doctor {
                     |  disallowMultipleDaemons = true
+                    |  ensureJavaHomeMatches = !System.getenv().containsKey("CI")
                     |}
                 """.trimMargin("|")
         )
@@ -115,6 +118,7 @@ class PluginIntegrationTest constructor(private val version: String) {
             }
             doctor {
               disallowMultipleDaemons = false
+              ensureJavaHomeMatches = !System.getenv().containsKey("CI")
             }
         """.trimIndent())
 

--- a/doctor-plugin/src/test/java/com/osacky/doctor/TestDaggerTime.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/TestDaggerTime.kt
@@ -20,6 +20,7 @@ class TestDaggerTime {
                     doctor {
                       disallowMultipleDaemons = false
                       daggerThreshold = 100
+                      ensureJavaHomeMatches = !System.getenv().containsKey("CI")
                     }
         """.trimIndent())
         testProjectRoot.newFile("settings.gradle").writeText("""


### PR DESCRIPTION
This is better than checking if multiple daemons are running.
The multiple daemon check is now disabled by default.