### PR TITLE
Follow symlinks when checking java home.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ doctor {
    * By default, Gradle caches test results. This can be dangerous if tests rely on timestamps, dates, or other files
    * which are not declared as inputs.
    */
-  enableTestCaching = false
+  enableTestCaching = true
   /**
    * By default, Gradle treats empty directories as inputs to compilation tasks. This can cause cache misses.
    */

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
@@ -29,7 +29,7 @@ open class DoctorExtension {
      * By default, Gradle caches test results. This can be dangerous if tests rely on timestamps, dates, or other files
      * which are not declared as inputs.
      */
-    var enableTestCaching = false
+    var enableTestCaching = true
     /**
      * By default, Gradle treats empty directories as inputs to compilation tasks. This can cause cache misses.
      */

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -2,6 +2,7 @@ package com.osacky.doctor
 
 import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.PillBoxPrinter
+import java.io.File
 import org.gradle.api.GradleException
 import org.gradle.internal.jvm.Jvm
 
@@ -22,8 +23,8 @@ class JavaHomeCheck(
         if (extension.ensureJavaHomeMatches && !isGradleUsingJavaHome()) {
             throw GradleException(pillBoxPrinter.createPill("""
                 |Gradle is not using JAVA_HOME.
-                |JAVA_HOME is $environmentJavaHome
-                |Gradle is using $gradleJavaHome
+                |JAVA_HOME is ${environmentJavaHome.toFile().toPath().toAbsolutePath()}
+                |Gradle is using ${gradleJavaHome.toPath().toAbsolutePath()}
                 |This can slow down your build significantly when switching from Android Studio to the terminal.
                 |To fix: Project Structure -> JDK Location.
                 |Set this to your JAVA_HOME.
@@ -39,9 +40,12 @@ class JavaHomeCheck(
     private val gradleJavaHome = Jvm.current().javaHome
 
     private fun isGradleUsingJavaHome(): Boolean {
-        if (environmentJavaHome != null && gradleJavaHome.startsWith(environmentJavaHome)) {
+        // Follow symlinks when checking that java home matches.
+        if (environmentJavaHome != null && gradleJavaHome.toPath().toRealPath() == File(environmentJavaHome).toPath().toRealPath()) {
             return true
         }
         return false
     }
+
+    private fun String.toFile() = File(this)
 }

--- a/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
@@ -18,7 +18,7 @@ class PluginIntegrationTest constructor(private val version: String) {
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
         fun getParams(): List<String> {
-            return listOf("5.0", "5.1", "5.3", "5.6", "6.0.1", "6.1.1")
+            return listOf("5.0", "5.3", "5.6", "6.0.1", "6.1.1")
         }
     }
 


### PR DESCRIPTION
This ensures that even if we are using sdkman to manage java versions,
we can still get the proper result.

Fixes #40.

Also enables test caching by default so as not to change default gradle
features.
Fixes #39