### PR TITLE
Fix NPE.

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperations.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperations.kt
@@ -62,8 +62,10 @@ class BuildOperations(gradle: Gradle) : OperationEvents {
         val hashes = mutableListOf<HashCode>()
         executeTaskIdsMap.entries.forEach { entry ->
             if (entry.value.skipMessage == null) {
-                if (snapshotIdsMap.containsKey(entry.key)) {
-                    hashes.add(HashCode.fromBytes(snapshotIdsMap[entry.key]!!.hashBytes!!))
+                val bytes = snapshotIdsMap[entry.key]?.hashBytes
+                // hashBytes Can be null if inputs are invalid.
+                if (bytes != null) {
+                    hashes.add(HashCode.fromBytes(bytes))
                 }
             }
         }


### PR DESCRIPTION
Hashbytes can be null if the inputs are invalid.