### PR TITLE
Measure time correctly for download speed.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
     classpath("com.osacky.doctor:doctor-plugin:1.0")
   }
 }

--- a/doctor-plugin/build.gradle.kts
+++ b/doctor-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version "1.3.71"
+    kotlin("jvm") version "1.3.72"
     id("com.gradle.plugin-publish") version "0.11.0"
     id("org.jmailen.kotlinter") version "2.3.2"
     `maven-publish`
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
     implementation("io.reactivex.rxjava3:rxjava:3.0.2")
     testImplementation(gradleTestKit())
     testImplementation("junit:junit:4.13")

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -4,6 +4,7 @@ import com.osacky.doctor.internal.Clock
 import com.osacky.doctor.internal.DaemonCheck
 import com.osacky.doctor.internal.DirtyBeanCollector
 import com.osacky.doctor.internal.Finish
+import com.osacky.doctor.internal.IntervalMeasurer
 import com.osacky.doctor.internal.PillBoxPrinter
 import com.osacky.doctor.internal.SystemClock
 import org.gradle.api.GradleException
@@ -26,14 +27,15 @@ class DoctorPlugin : Plugin<Project> {
         val extension = target.extensions.create<DoctorExtension>("doctor")
 
         val clock: Clock = SystemClock()
+        val intervalMeasurer = IntervalMeasurer()
         val pillBoxPrinter = PillBoxPrinter(target.logger)
         val daemonChecker = BuildDaemonChecker(extension, DaemonCheck(), pillBoxPrinter)
         val javaHomeCheck = JavaHomeCheck(extension, pillBoxPrinter)
         val garbagePrinter = GarbagePrinter(clock, DirtyBeanCollector(), extension)
         val operations = BuildOperations(target.gradle)
         val javaAnnotationTime = JavaAnnotationTime(operations, extension, target.buildscript.configurations)
-        val downloadSpeedMeasurer = DownloadSpeedMeasurer(operations, extension)
-        val buildCacheConnectionMeasurer = BuildCacheConnectionMeasurer(operations, extension)
+        val downloadSpeedMeasurer = DownloadSpeedMeasurer(operations, extension, intervalMeasurer)
+        val buildCacheConnectionMeasurer = BuildCacheConnectionMeasurer(operations, extension, intervalMeasurer)
         val buildCacheKey = RemoteCacheEstimation(operations, target, clock)
         val list = listOf(daemonChecker, javaHomeCheck, garbagePrinter, javaAnnotationTime, downloadSpeedMeasurer, buildCacheConnectionMeasurer, buildCacheKey)
         garbagePrinter.onStart()

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/IntervalMeasurer.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/IntervalMeasurer.kt
@@ -1,0 +1,29 @@
+package com.osacky.doctor.internal
+
+import kotlin.math.max
+
+class IntervalMeasurer {
+
+    /**
+     * Find the total time elapsed based on the union of the time intervals.
+     * This is based on the following Stackoverflow answer but converted to Kotlin:
+     * https://codereview.stackexchange.com/questions/126906/finding-the-total-time-elapsed-in-the-union-of-time-intervals
+     */
+    fun findTotalTime(intervals: List<Pair<Long, Long>>): Long {
+        if (intervals.isEmpty()) {
+            return 0L
+        }
+        val sorted = intervals.sortedBy { it.first }
+        var totalTime = 0L
+        var currentEnd = intervals[0].first
+
+        sorted.forEach { interval ->
+            if (interval.second > currentEnd) {
+                totalTime += interval.second - max(interval.first, currentEnd)
+                currentEnd = interval.second
+            }
+        }
+
+        return totalTime
+    }
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/SlowNetworkPrinter.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/SlowNetworkPrinter.kt
@@ -2,7 +2,7 @@ package com.osacky.doctor.internal
 
 class SlowNetworkPrinter(private val type: String) {
 
-    fun obtainMessage(totalBytes: Int, totalTime: Int, totalSpeed: Float): String {
+    fun obtainMessage(totalBytes: Int, totalTime: Long, totalSpeed: Float): String {
         val megabytesDownloaded = twoDigits.format(totalBytes * 1.0f / ONE_MEGABYTE)
         val secondsDownloading = twoDigits.format(totalTime * 1.0f / 1000)
         val totalSpeedFormatted = twoDigits.format(totalSpeed)

--- a/doctor-plugin/src/test/java/com/osacky/doctor/internal/IntervalMeasurerTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/internal/IntervalMeasurerTest.kt
@@ -1,0 +1,36 @@
+package com.osacky.doctor.internal
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class IntervalMeasurerTest {
+
+    val underTest = IntervalMeasurer()
+
+    @Test
+    fun testSingleInterval() {
+        val totalTime = underTest.findTotalTime(listOf(0L to 1L))
+
+        assertThat(totalTime).isEqualTo(1L)
+    }
+
+    @Test
+    fun testThreeOverlappingIntervals() {
+        val totalTime = underTest.findTotalTime(listOf((0L to 1L), (0L to 1L), (0L to 1L)))
+
+        assertThat(totalTime).isEqualTo(1L)
+    }
+
+    @Test
+    fun testOverlappingIntervals() {
+        val totalTime = underTest.findTotalTime(listOf((0L to 1L), (0L to 1L), (0L to 4)))
+
+        assertThat(totalTime).isEqualTo(4)
+    }
+    @Test
+    fun testNonOverlappingIntervals() {
+        val totalTime = underTest.findTotalTime(listOf((0L to 1L), (0L to 1L), (4L to 6L)))
+
+        assertThat(totalTime).isEqualTo(3)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx3g
 
 kotlin.code.style=official
 org.gradle.parallel=true


### PR DESCRIPTION
Instead of adding up all the time spent downloading, we need to find the
union of all the intervals spent downloading otherwise the total
download time could be longer than the build.