### PR TITLE
Fix confusing error message with slow network.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ tasks.withType(Test::class.java).configureEach {
 
 tasks.wrapper {
   distributionType = Wrapper.DistributionType.ALL
-  gradleVersion = "6.6-rc-3"
+  gradleVersion = "6.6-rc-6"
 }
 
 buildScan {

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/SlowNetworkPrinter.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/SlowNetworkPrinter.kt
@@ -9,7 +9,7 @@ class SlowNetworkPrinter(private val type: String) {
         return """
                     Detected a slow download speed downloading from $type.
                     $megabytesDownloaded MB downloaded in $secondsDownloading s
-                    Total speed from cache = $totalSpeedFormatted MB/s
+                    Total speed from $type = $totalSpeedFormatted MB/s
         """.trimIndent()
     }
 

--- a/doctor-plugin/src/test/java/com/osacky/doctor/internal/SlowNetworkPrinterTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/internal/SlowNetworkPrinterTest.kt
@@ -14,7 +14,7 @@ class SlowNetworkPrinterTest {
             """
              Detected a slow download speed downloading from Fake Repository.
              0 MB downloaded in 0 s
-             Total speed from cache = 0 MB/s
+             Total speed from Fake Repository = 0 MB/s
             """.trimIndent()
         )
     }
@@ -26,7 +26,7 @@ class SlowNetworkPrinterTest {
             """
              Detected a slow download speed downloading from Fake Repository.
              0.1 MB downloaded in 0.05 s
-             Total speed from cache = 0.1 MB/s
+             Total speed from Fake Repository = 0.1 MB/s
             """.trimIndent()
         )
     }
@@ -38,7 +38,7 @@ class SlowNetworkPrinterTest {
             """
              Detected a slow download speed downloading from Fake Repository.
              9.54 MB downloaded in 1.7 s
-             Total speed from cache = 1.01 MB/s
+             Total speed from Fake Repository = 1.01 MB/s
             """.trimIndent()
         )
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-rc-6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -40,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto init
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -54,7 +54,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto init
+if exist "%JAVA_EXE%" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -64,21 +64,6 @@ echo location of your Java installation.
 
 goto fail
 
-:init
-@rem Get command-line arguments, handling Windows variants
-
-if not "%OS%" == "Windows_NT" goto win9xME_args
-
-:win9xME_args
-@rem Slurp the command line arguments.
-set CMD_LINE_ARGS=
-set _SKIP=2
-
-:win9xME_args_slurp
-if "x%~1" == "x" goto execute
-
-set CMD_LINE_ARGS=%*
-
 :execute
 @rem Setup the command line
 
@@ -86,7 +71,7 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
This previously always printed out the word "cache" even when the slow download was from maven repositories.
