### PR TITLE
Add initial configuration cache compatibility.

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildFinishService.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildFinishService.kt
@@ -1,0 +1,21 @@
+package com.osacky.doctor
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.util.LinkedList
+
+abstract class BuildFinishService : BuildService<BuildServiceParameters.None>, AutoCloseable {
+
+    private val closeList = LinkedList<AutoCloseable>()
+
+    fun closeMeWhenFinished(closeable: AutoCloseable) {
+        closeList.push(closeable)
+    }
+
+    override fun close() {
+        for (item in closeList) {
+            item.close()
+        }
+        closeList.clear()
+    }
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CoCaHelpers.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CoCaHelpers.kt
@@ -1,0 +1,6 @@
+package com.osacky.doctor.internal
+
+import org.gradle.api.invocation.Gradle
+import org.gradle.util.GradleVersion
+
+fun Gradle.shouldUseCoCaClasses(): Boolean = GradleVersion.version(gradleVersion) >= GradleVersion.version("6.5")

--- a/doctor-plugin/src/test/java/com/osacky/doctor/ConfigurationCacheTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/ConfigurationCacheTest.kt
@@ -1,0 +1,46 @@
+package com.osacky.doctor
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ConfigurationCacheTest {
+    @get:Rule
+    val testProjectRoot = TemporaryFolder()
+
+    @Test
+    fun configurationCacheWorks() {
+        testProjectRoot.writeBuildGradle(
+            """
+                    |plugins {
+                    |  id "com.osacky.doctor"
+                    |}
+                    |doctor {
+                    |  disallowMultipleDaemons = false
+                    |  ensureJavaHomeMatches = false
+                    |}
+                """.trimMargin("|")
+        )
+        val fixtureName = "java-fixture"
+        testProjectRoot.writeFileToName("settings.gradle", "include '$fixtureName'")
+        testProjectRoot.setupFixture(fixtureName)
+
+        val runner = GradleRunner.create()
+            .forwardOutput()
+            .withArguments("assemble", "--configuration-cache")
+            .withProjectDir(testProjectRoot.root)
+            .withGradleVersion("6.6")
+            .withPluginClasspath()
+
+        val result = runner.build()
+
+        assertThat(result.output).contains("Configuration cache entry stored.")
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+
+        val resultTwo = runner.build()
+        assertThat(resultTwo.output).contains("Reusing configuration cache.")
+        assertThat(resultTwo.output).contains("BUILD SUCCESSFUL")
+    }
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/GradleProjects.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/GradleProjects.kt
@@ -1,0 +1,11 @@
+package com.osacky.doctor
+
+import org.junit.rules.TemporaryFolder
+
+fun TemporaryFolder.writeBuildGradle(build: String) {
+    writeFileToName("build.gradle", build)
+}
+
+fun TemporaryFolder.writeFileToName(fileName: String, contents: String) {
+    newFile(fileName).writeText(contents)
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
@@ -160,7 +160,7 @@ class PluginIntegrationTest constructor(private val version: String) {
             """.trimIndent()
         )
 
-        writeFileToName(
+        testProjectRoot.writeFileToName(
             "settings.gradle",
             """
             include 'app-one'
@@ -237,7 +237,7 @@ class PluginIntegrationTest constructor(private val version: String) {
             """.trimIndent()
         )
 
-        writeFileToName(
+        testProjectRoot.writeFileToName(
             "settings.gradle",
             """
             include 'app-one'
@@ -362,11 +362,7 @@ class PluginIntegrationTest constructor(private val version: String) {
     }
 
     private fun writeBuildGradle(build: String) {
-        writeFileToName("build.gradle", build)
-    }
-
-    private fun writeFileToName(fileName: String, contents: String) {
-        testProjectRoot.newFile(fileName).writeText(contents)
+        testProjectRoot.writeBuildGradle(build)
     }
 
     private fun createFileInFolder(folder: File, fileName: String, contents: String) {


### PR DESCRIPTION
This stops any configuraiton cache warnings from happening during a normal build. This does not mean that the build is fully compatibly with configuration caching or that it even works.

Ref #71
