### PR TITLE
Remove `Finish` and allow multiple warnings. 

### DIFF
--- a/doctor-plugin/build.gradle.kts
+++ b/doctor-plugin/build.gradle.kts
@@ -48,6 +48,10 @@ gradlePlugin {
     }
 }
 
+kotlinter {
+  indentSize = 4
+}
+
 
 kotlinDslPluginOptions {
     experimentalWarning.set(false)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildCacheConnectionMeasurer.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildCacheConnectionMeasurer.kt
@@ -1,7 +1,6 @@
 package com.osacky.doctor
 
 import com.osacky.doctor.BuildCacheConnectionMeasurer.ExternalDownloadEvent.Companion.fromGradleType
-import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.IntervalMeasurer
 import com.osacky.doctor.internal.SlowNetworkPrinter
 import com.osacky.doctor.internal.SlowNetworkPrinter.Companion.ONE_MEGABYTE
@@ -31,7 +30,7 @@ class BuildCacheConnectionMeasurer(
             }
     }
 
-    override fun onFinish(): Finish {
+    override fun onFinish(): List<String> {
         // Dispose first before summing byte totals otherwise we get crazy NPEs?
         disposable.dispose()
 
@@ -42,17 +41,17 @@ class BuildCacheConnectionMeasurer(
 
             // Don't do anything if we didn't download anything.
             if (totalBytes == 0 || totalTime == 0L) {
-                return Finish.None
+                return emptyList()
             }
 
             // Only print time if we downloaded at least one megabyte
             if (totalBytes > ONE_MEGABYTE) {
                 val totalSpeed = (totalBytes / totalTime) / 1024f
                 if (totalSpeed < extension.downloadSpeedWarningThreshold.get()) {
-                    return Finish.FinishMessage(slowNetworkPrinter.obtainMessage(totalBytes, totalTime, totalSpeed))
+                    return listOf(slowNetworkPrinter.obtainMessage(totalBytes, totalTime, totalSpeed))
                 }
             }
-            return Finish.None
+            return emptyList()
         }
     }
 

--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildDaemonChecker.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildDaemonChecker.kt
@@ -1,7 +1,6 @@
 package com.osacky.doctor
 
 import com.osacky.doctor.internal.DaemonCheck
-import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.PillBoxPrinter
 import org.gradle.api.GradleException
 
@@ -30,5 +29,5 @@ class BuildDaemonChecker(private val extension: DoctorExtension, private val dae
         }
     }
 
-    override fun onFinish(): Finish = Finish.None
+    override fun onFinish(): List<String> = emptyList()
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildStartFinishListener.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildStartFinishListener.kt
@@ -1,8 +1,10 @@
 package com.osacky.doctor
 
-import com.osacky.doctor.internal.Finish
-
 interface BuildStartFinishListener {
     fun onStart()
-    fun onFinish(): Finish
+    /**
+     * Called when the build is finished to perform any clean up actions
+     * @return A list of warnings to print out at the end of the build.
+     */
+    fun onFinish(): List<String>
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -3,7 +3,6 @@ package com.osacky.doctor
 import com.osacky.doctor.internal.Clock
 import com.osacky.doctor.internal.DaemonCheck
 import com.osacky.doctor.internal.DirtyBeanCollector
-import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.IntervalMeasurer
 import com.osacky.doctor.internal.PillBoxPrinter
 import com.osacky.doctor.internal.SystemClock
@@ -32,7 +31,7 @@ class DoctorPlugin : Plugin<Project> {
         val intervalMeasurer = IntervalMeasurer()
         val pillBoxPrinter = PillBoxPrinter(target.logger)
         val daemonChecker = BuildDaemonChecker(extension, DaemonCheck(), pillBoxPrinter)
-        val javaHomeCheck = JavaHomeCheck(extension, pillBoxPrinter, target.logger)
+        val javaHomeCheck = JavaHomeCheck(extension, pillBoxPrinter)
         val garbagePrinter = GarbagePrinter(clock, DirtyBeanCollector(), extension)
         val operations = BuildOperations(target.gradle)
         val javaAnnotationTime = JavaAnnotationTime(operations, extension, target.buildscript.configurations)
@@ -52,12 +51,12 @@ class DoctorPlugin : Plugin<Project> {
         }
 
         val runnable = Runnable {
-            val thingsToPrint = list.map { it.onFinish() }.filterIsInstance(Finish.FinishMessage::class.java)
+            val thingsToPrint: List<String> = list.flatMap { it.onFinish() }
             if (thingsToPrint.isEmpty()) {
                 return@Runnable
             }
 
-            pillBoxPrinter.writePrescription(thingsToPrint.map { it.message })
+            pillBoxPrinter.writePrescription(thingsToPrint)
         }
 
         if (target.gradle.shouldUseCoCaClasses()) {

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DownloadSpeedMeasurer.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DownloadSpeedMeasurer.kt
@@ -1,7 +1,6 @@
 package com.osacky.doctor
 
 import com.osacky.doctor.DownloadSpeedMeasurer.ExternalDownloadEvent.Companion.fromGradleType
-import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.IntervalMeasurer
 import com.osacky.doctor.internal.SlowNetworkPrinter
 import com.osacky.doctor.internal.SlowNetworkPrinter.Companion.ONE_MEGABYTE
@@ -29,7 +28,7 @@ class DownloadSpeedMeasurer(
             }
     }
 
-    override fun onFinish(): Finish {
+    override fun onFinish(): List<String> {
         // Dispose first before summing byte totals otherwise we get crazy NPEs?
         disposable.dispose()
 
@@ -40,18 +39,18 @@ class DownloadSpeedMeasurer(
 
             // Don't do anything if we didn't download anything.
             if (totalBytes == 0 || totalTime == 0L) {
-                return Finish.None
+                return emptyList()
             }
             val totalSpeed = (totalBytes / totalTime) / 1024f
 
             // Only print time if we downloaded at least one megabyte
             if (totalBytes > ONE_MEGABYTE) {
                 if (totalSpeed < extension.downloadSpeedWarningThreshold.get()) {
-                    return Finish.FinishMessage(slowNetworkPrinter.obtainMessage(totalBytes, totalTime, totalSpeed))
+                    return listOf(slowNetworkPrinter.obtainMessage(totalBytes, totalTime, totalSpeed))
                 }
             }
         }
-        return Finish.None
+        return emptyList()
     }
 
     data class ExternalDownloadEvent(val start: Long, val end: Long, val byteTotal: Long) {

--- a/doctor-plugin/src/main/java/com/osacky/doctor/GarbagePrinter.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/GarbagePrinter.kt
@@ -2,7 +2,6 @@ package com.osacky.doctor
 
 import com.osacky.doctor.internal.Clock
 import com.osacky.doctor.internal.DirtyBeanCollector
-import com.osacky.doctor.internal.Finish
 import java.text.NumberFormat
 
 class GarbagePrinter(
@@ -19,7 +18,7 @@ class GarbagePrinter(
     override fun onStart() {
     }
 
-    override fun onFinish(): Finish {
+    override fun onFinish(): List<String> {
         val endGarbageTime = collector.collect()
         val endBuildTime = clock.upTimeMillis()
 
@@ -35,8 +34,8 @@ class GarbagePrinter(
                 Otherwise, if this is happening after several builds it could indicate a memory leak.
                 For a quick fix, restart this Gradle daemon. ./gradlew --stop
                 """.trimIndent()
-            return Finish.FinishMessage(message)
+            return listOf(message)
         }
-        return Finish.None
+        return emptyList()
     }
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaAnnotationTime.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaAnnotationTime.kt
@@ -1,6 +1,5 @@
 package com.osacky.doctor
 
-import com.osacky.doctor.internal.Finish
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
 import org.gradle.api.artifacts.ConfigurationContainer
@@ -37,13 +36,13 @@ class JavaAnnotationTime(
         add(disposable)
     }
 
-    override fun onFinish(): Finish {
+    override fun onFinish(): List<String> {
         disposable.dispose()
         if (totalDaggerTime > doctorExtension.daggerThreshold.get()) {
             val message = if (containsDelect()) enableReflectMessage else applyDelectPlugin
-            return Finish.FinishMessage("This build spent ${totalDaggerTime / 1000f} s in Dagger Annotation Processors.\n$message")
+            return listOf("This build spent ${totalDaggerTime / 1000f} s in Dagger Annotation Processors.\n$message")
         }
-        return Finish.None
+        return emptyList()
     }
 
     private val applyDelectPlugin =

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -1,17 +1,14 @@
 package com.osacky.doctor
 
-import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.PillBoxPrinter
 import org.gradle.api.GradleException
-import org.gradle.api.logging.Logger
 import org.gradle.internal.jvm.Jvm
 import java.io.File
 import java.util.Collections
 
 class JavaHomeCheck(
     private val extension: DoctorExtension,
-    private val pillBoxPrinter: PillBoxPrinter,
-    private val logger: Logger
+    private val pillBoxPrinter: PillBoxPrinter
 ) : BuildStartFinishListener {
 
     private val recordedErrors = Collections.synchronizedSet(LinkedHashSet<String>())
@@ -61,11 +58,8 @@ class JavaHomeCheck(
         }
     }
 
-    override fun onFinish(): Finish {
-        if (recordedErrors.isNotEmpty()) {
-            logger.error(recordedErrors.joinToString("\n\n"))
-        }
-        return Finish.None
+    override fun onFinish(): List<String> {
+        return recordedErrors.toList()
     }
 
     private val environmentJavaHome = System.getenv("JAVA_HOME")

--- a/doctor-plugin/src/main/java/com/osacky/doctor/RemoteCacheEstimation.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/RemoteCacheEstimation.kt
@@ -1,7 +1,6 @@
 package com.osacky.doctor
 
 import com.osacky.doctor.internal.Clock
-import com.osacky.doctor.internal.Finish
 import com.osacky.doctor.internal.SlowNetworkPrinter.Companion.ONE_MEGABYTE
 import com.osacky.doctor.internal.twoDigits
 import org.gradle.BuildListener
@@ -49,9 +48,9 @@ class RemoteCacheEstimation(
         }
     }
 
-    override fun onFinish(): Finish {
+    override fun onFinish(): List<String> {
         if (!benchmarkBuildCache) {
-            return Finish.None
+            return emptyList()
         }
         project.gradle.removeListener(listener)
 
@@ -63,7 +62,7 @@ class RemoteCacheEstimation(
         }
 
         if (cacheSizeBytes == 0) {
-            return Finish.FinishMessage(
+            return listOf(
                 """
                 = Remote Build Cache Benchmark Report =
                 This build did not generate any cached artifacts.
@@ -88,7 +87,7 @@ class RemoteCacheEstimation(
         val twoMBSavings = executionTimeSec - twoMBTime
         val tenMBSavings = executionTimeSec - tenMBTime
 
-        return Finish.FinishMessage(
+        return listOf(
             """
             = Remote Build Cache Benchmark Report =
             Forced re-execution of ${buildOperations.tasksRan()} tasks in order to calculate local execution duration.

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/Finish.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/Finish.kt
@@ -1,6 +1,0 @@
-package com.osacky.doctor.internal
-
-sealed class Finish {
-    object None : Finish()
-    data class FinishMessage(val message: String) : Finish()
-}


### PR DESCRIPTION
This removes the `Finish` class in favor of just returning a list of strings.
This allows a single class to return multiple warnings at the end of the build.
This also removes the direct usage of the logger from the `JavaHomeCheck`.