### PR TITLE
Print tasks with negative avoidance savings.

### DIFF
--- a/docs/slower-from-cache.md
+++ b/docs/slower-from-cache.md
@@ -1,0 +1,49 @@
+# Slower From Cache
+
+Some tasks may be slower to pull from the Gradle Build cache.
+In general, tasks that are computationally cheap but expensive on the disk are not good candidates to be cached.
+
+### Copy tasks
+A copy task should not be cached. The output of a copy task would need to be compressed and then stored in
+the build cache. To restore the copy task from the cache, Gradle would decompress the outputs and then rewrite them in
+the output directories. Simply performing the copy again would simply move the files from their original location without
+need to compress and then decompress them.
+
+### Non compressible outputs
+Tasks which generate large output which is not easily compressible may also not be good candidates for the build cache.
+Tasks that move compressed images like pngs, jpegs, or precomputed libraries are not good caching candidates.
+
+### Disabling caching
+
+=== "Groovy"
+    ``` groovy
+    tasks.named("<taskname>").configure {
+        outputs.cacheIf { false }
+    }
+    ```
+=== "Kotlin"
+    ``` kotlin
+    tasks.named('<taskname>').configure {
+        outputs.cacheIf { false }
+    }
+    ```
+
+### Disabling remote caching
+Some Gradle tasks may be beneficial to cache locally but not on CI. There is currently no mechanism to only disable
+remote caching of tasks. A workaround is to disable the cache entry being placed in to the remote build cache.
+
+=== "Groovy"
+    ``` groovy
+    tasks.named('<taskname>').configure {
+        outputs.cacheIf { !isCI }
+    }
+    ```
+=== "Kotlin"
+    ``` kotlin
+    tasks.named("<taskname>").configure {
+        outputs.cacheIf { !isCI }
+    }
+    ```
+
+See [Remote Build Cache Benchmark](/remote-cache) for more information on estimating whether it is beneficial
+to remotely cache tasks.

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -44,13 +44,15 @@ class DoctorPlugin : Plugin<Project> {
         val downloadSpeedMeasurer = DownloadSpeedMeasurer(buildOperations, extension, intervalMeasurer)
         val buildCacheConnectionMeasurer = BuildCacheConnectionMeasurer(buildOperations, extension, intervalMeasurer)
         val buildCacheKey = RemoteCacheEstimation((buildOperations as BuildOperations), target, clock)
-        val list = listOf(daemonChecker, javaHomeCheck, garbagePrinter, javaAnnotationTime, downloadSpeedMeasurer, buildCacheConnectionMeasurer, buildCacheKey)
+        val slowerFromCacheCollector = buildOperations.slowerFromCacheCollector()
+        val list = listOf(daemonChecker, javaHomeCheck, garbagePrinter, javaAnnotationTime, downloadSpeedMeasurer, buildCacheConnectionMeasurer, buildCacheKey, slowerFromCacheCollector)
 
         garbagePrinter.onStart()
         javaAnnotationTime.onStart()
         downloadSpeedMeasurer.onStart()
         buildCacheConnectionMeasurer.onStart()
         buildCacheKey.onStart()
+        slowerFromCacheCollector.onStart()
         target.afterEvaluate {
             daemonChecker.onStart()
             javaHomeCheck.onStart()

--- a/doctor-plugin/src/main/java/com/osacky/doctor/SlowerFromCacheCollector.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/SlowerFromCacheCollector.kt
@@ -1,0 +1,34 @@
+package com.osacky.doctor
+
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.OperationFinishEvent
+
+/**
+ * Keeps track of which classes were slower to fetch from the cache than to re-run locally.
+ */
+class SlowerFromCacheCollector : BuildStartFinishListener {
+
+    private val longerTaskList = mutableListOf<String>()
+
+    fun onEvent(buildOperation: BuildOperationDescriptor, finishEvent: OperationFinishEvent) {
+        val executeResult = finishEvent.result
+        if (executeResult is ExecuteTaskBuildOperationType.Result) {
+            val duration = finishEvent.endTime - finishEvent.startTime
+            // If the current execution took longer than the original execution, let's print out a warning.
+            if (executeResult.originExecutionTime != null && executeResult.originExecutionTime!! <= duration) {
+                longerTaskList.add(buildOperation.displayName)
+            }
+        }
+    }
+
+    override fun onStart() {
+    }
+
+    override fun onFinish(): List<String> {
+        if (longerTaskList.isEmpty()) {
+            return emptyList()
+        }
+        return listOf("The following operations were slower to pull from the cache than to rerun:\n${longerTaskList.joinToString(separator = "\n")}\nConsider disabling caching them. For more information see: https://runningcode.github.io/gradle-doctor/slower-from-cache/")
+    }
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/SlowerFromCacheCollectorTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/SlowerFromCacheCollectorTest.kt
@@ -1,0 +1,69 @@
+package com.osacky.doctor
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.OperationFinishEvent
+import org.junit.Test
+
+internal class SlowerFromCacheCollectorTest {
+
+    val underTest = SlowerFromCacheCollector()
+
+    @Test
+    fun fasterToReExecuteTaskWarned() {
+        underTest.onEvent(descriptorWithName("fasterToReExecute"), finishWithTime(5))
+
+        assertThat(underTest.onFinish()).containsExactly("The following operations were slower to pull from the cache than to rerun:\nfasterToReExecute\nConsider disabling caching them. For more information see: https://runningcode.github.io/gradle-doctor/slower-from-cache/")
+    }
+
+    @Test
+    fun noWarningWhenFasterFromCache() {
+        underTest.onEvent(descriptorWithName("fasterFromCache"), finishWithTime(200))
+
+        assertThat(underTest.onFinish()).isEmpty()
+    }
+
+    fun finishWithTime(originExecutionTime: Long): OperationFinishEvent {
+        return OperationFinishEvent(0, 6, null, Result(originExecutionTime))
+    }
+
+    fun descriptorWithName(name: String): BuildOperationDescriptor {
+        return BuildOperationDescriptor.displayName(name)
+            .build()
+    }
+
+    internal class Result(private val originExecutionTime: Long) : ExecuteTaskBuildOperationType.Result {
+        override fun getSkipMessage(): String? {
+            throw NotImplementedError()
+        }
+
+        override fun isActionable(): Boolean {
+            throw NotImplementedError()
+        }
+
+        override fun getOriginBuildInvocationId(): String? {
+            throw NotImplementedError()
+        }
+
+        override fun getOriginExecutionTime(): Long? {
+            return originExecutionTime
+        }
+
+        override fun getCachingDisabledReasonMessage(): String? {
+            throw NotImplementedError()
+        }
+
+        override fun getCachingDisabledReasonCategory(): String? {
+            throw NotImplementedError()
+        }
+
+        override fun getUpToDateMessages(): MutableList<String> {
+            throw NotImplementedError()
+        }
+
+        override fun isIncremental(): Boolean {
+            throw NotImplementedError()
+        }
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
   - Changelog: changelog.md
   - Remote Cache Benchmark: remote-cache.md
   - Releasing: releasing.md
+  - Slower From Cache: slower-from-cache.md
 
 theme:
   name: 'material'


### PR DESCRIPTION
When a task is pulled from the cache and takes longer to pull from the cache than the original
execution time, display a warning at the end of the build.

Ref #86
