### PR TITLE
Fix race condition accessing HashMap.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.6.3
+* Fix ClassCastException caused by race condition. [PR](https://github.com/runningcode/gradle-doctor/pull/129)
+
 ## 0.6.2
 * [Add threshold for negative avoidance savings.](https://github.com/runningcode/gradle-doctor/pull/126)
 

--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperations.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperations.kt
@@ -13,11 +13,13 @@ import org.gradle.internal.operations.OperationFinishEvent
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
+import java.util.concurrent.ConcurrentHashMap
 
 class BuildOperations(negativeAvoidanceThreshold: Property<Int>) : OperationEvents, BuildOperationListener {
 
     // TODO move this out of this class
-    private val snapshotIdsMap = HashMap<OperationIdentifier, SnapshotTaskInputsBuildOperationType.Result>()
+    // When multiple threads are accessing this HashMap, a ClassCastException may be thrown.
+    private val snapshotIdsMap = ConcurrentHashMap<OperationIdentifier, SnapshotTaskInputsBuildOperationType.Result>()
     private val executeTaskIdsMap = HashMap<OperationIdentifier, ExecuteTaskBuildOperationType.Result>()
 
     private val starts: PublishSubject<OperationStartEvent> = PublishSubject.create()


### PR DESCRIPTION
The race condition was causing:
`java.lang.ClassCastException: java.util.HashMap$Node cannot be cast to java.util.HashMap$TreeNode`
