### PR TITLE
Correct gradle version When we should use configuration caching 

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CoCaHelpers.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CoCaHelpers.kt
@@ -3,4 +3,4 @@ package com.osacky.doctor.internal
 import org.gradle.api.invocation.Gradle
 import org.gradle.util.GradleVersion
 
-fun Gradle.shouldUseCoCaClasses(): Boolean = GradleVersion.version(gradleVersion) >= GradleVersion.version("6.5")
+fun Gradle.shouldUseCoCaClasses(): Boolean = GradleVersion.version(gradleVersion) >= GradleVersion.version("6.6")


### PR DESCRIPTION
there's Just a small mistake about [Gradle.shouldUseCoCaClasses()](https://github.com/runningcode/gradle-doctor/blob/master/doctor-plugin/src/main/java/com/osacky/doctor/internal/CoCaHelpers.kt), it assumes that Configuration caching feature is available since gradle 6.5

**The correct is**:
 gradle 6.6, ref [Gradle 6.6 Release notes](https://docs.gradle.org/6.6/release-notes.html).