### PR TITLE
Slower from cache callback

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperationListenerService.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperationListenerService.kt
@@ -14,10 +14,11 @@ abstract class BuildOperationListenerService : BuildService<BuildOperationListen
 
     interface Params : BuildServiceParameters {
         fun getNegativeAvoidanceThreshold(): Property<Int>
+        fun getSlowerFromCacheCallback(): Property<SlowerFromCacheCallback?>
     }
 
     // Needs to be created within the service since the lifecycle of the BuildService is controlled by Gradle.
-    private val buildOperations = BuildOperations(parameters.getNegativeAvoidanceThreshold())
+    private val buildOperations = BuildOperations(parameters.getNegativeAvoidanceThreshold(), parameters.getSlowerFromCacheCallback())
 
     override fun started(buildOperation: BuildOperationDescriptor, startEvent: OperationStartEvent) {
         buildOperations.started(buildOperation, startEvent)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperations.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/BuildOperations.kt
@@ -15,7 +15,7 @@ import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
 import java.util.concurrent.ConcurrentHashMap
 
-class BuildOperations(negativeAvoidanceThreshold: Property<Int>) : OperationEvents, BuildOperationListener {
+class BuildOperations(negativeAvoidanceThreshold: Property<Int>, slowerFromCacheCallback: Property<SlowerFromCacheCallback?>) : OperationEvents, BuildOperationListener {
 
     // TODO move this out of this class
     // When multiple threads are accessing this HashMap, a ClassCastException may be thrown.
@@ -26,7 +26,7 @@ class BuildOperations(negativeAvoidanceThreshold: Property<Int>) : OperationEven
     private val progress: PublishSubject<OperationProgressEvent> = PublishSubject.create()
     private val finishes: PublishSubject<OperationFinishEvent> = PublishSubject.create()
 
-    private val slowerFromCacheCollector = SlowerFromCacheCollector(negativeAvoidanceThreshold)
+    private val slowerFromCacheCollector = SlowerFromCacheCollector(negativeAvoidanceThreshold, slowerFromCacheCallback)
 
     override fun started(buildOperation: BuildOperationDescriptor, startEvent: OperationStartEvent) {
         starts.onNext(startEvent)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
@@ -66,6 +66,12 @@ open class DoctorExtension(objects: ObjectFactory) {
     fun javaHome(action: Action<JavaHomeHandler>) {
         action.execute(javaHomeHandler)
     }
+
+    val slowerFromCacheCallback = objects.property<SlowerFromCacheCallback?>().convention(null)
+}
+
+interface SlowerFromCacheCallback {
+    fun onSlowerFromCache(longerTaskList: List<String>)
 }
 
 abstract class JavaHomeHandler @Inject constructor(objects: ObjectFactory) {

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -176,12 +176,13 @@ class DoctorPlugin : Plugin<Project> {
         return if (target.gradle.shouldUseCoCaClasses()) {
             val listenerService = target.gradle.sharedServices.registerIfAbsent("listener-service", BuildOperationListenerService::class.java) {
                 this.parameters.getNegativeAvoidanceThreshold().set(extension.negativeAvoidanceThreshold)
+                this.parameters.getSlowerFromCacheCallback().set(extension.slowerFromCacheCallback)
             }
             val buildEventListenerRegistry: BuildEventListenerRegistryInternal = target.serviceOf()
             buildEventListenerRegistry.onOperationCompletion(listenerService)
             listenerService.get().getOperations()
         } else {
-            val ops = BuildOperations(extension.negativeAvoidanceThreshold)
+            val ops = BuildOperations(extension.negativeAvoidanceThreshold, extension.slowerFromCacheCallback)
             target.gradle.buildOperationListenerManager.addListener(ops)
             ops
         }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/SlowerFromCacheCollector.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/SlowerFromCacheCollector.kt
@@ -9,7 +9,7 @@ import org.gradle.internal.operations.OperationFinishEvent
 /**
  * Keeps track of which classes were slower to fetch from the cache than to re-run locally.
  */
-class SlowerFromCacheCollector(private val negativeAvoidanceThreshold: Provider<Int>) : BuildStartFinishListener, HasBuildScanTag {
+class SlowerFromCacheCollector(private val negativeAvoidanceThreshold: Provider<Int>, private val slowerFromCacheCallback: Provider<SlowerFromCacheCallback?>) : BuildStartFinishListener, HasBuildScanTag {
 
     private val longerTaskList = mutableListOf<String>()
 
@@ -33,6 +33,9 @@ class SlowerFromCacheCollector(private val negativeAvoidanceThreshold: Provider<
     override fun onFinish(): List<String> {
         if (longerTaskList.isEmpty()) {
             return emptyList()
+        }
+        if (slowerFromCacheCallback.isPresent) {
+            slowerFromCacheCallback.get().onSlowerFromCache(longerTaskList)
         }
         return listOf(
             "The following operations were slower to pull from the cache than to rerun:\n" +

--- a/doctor-plugin/src/main/java/com/osacky/doctor/SlowerFromCacheCollector.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/SlowerFromCacheCollector.kt
@@ -34,9 +34,7 @@ class SlowerFromCacheCollector(private val negativeAvoidanceThreshold: Provider<
         if (longerTaskList.isEmpty()) {
             return emptyList()
         }
-        if (slowerFromCacheCallback.isPresent) {
-            slowerFromCacheCallback.get().onSlowerFromCache(longerTaskList)
-        }
+        slowerFromCacheCallback.orNull?.onSlowerFromCache(longerTaskList)
         return listOf(
             "The following operations were slower to pull from the cache than to rerun:\n" +
                 "${longerTaskList.joinToString(separator = "\n")}\nConsider disabling caching them.\n" +

--- a/doctor-plugin/src/test/java/com/osacky/doctor/SlowerFromCacheCollectorTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/SlowerFromCacheCollectorTest.kt
@@ -1,6 +1,7 @@
 package com.osacky.doctor
 
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -26,6 +27,7 @@ internal class SlowerFromCacheCollectorTest {
         val callback: SlowerFromCacheCallback = mock()
         val collector = SlowerFromCacheCollector(Providers.of(0), Providers.of(callback))
         collector.onEvent(descriptorWithName("fasterToReExecute"), finishWithTime(5))
+        collector.onFinish()
 
         verify(callback).onSlowerFromCache(listOf("fasterToReExecute"))
     }
@@ -42,8 +44,9 @@ internal class SlowerFromCacheCollectorTest {
         val callback: SlowerFromCacheCallback = mock()
         val collector = SlowerFromCacheCollector(Providers.of(0), Providers.of(callback))
         collector.onEvent(descriptorWithName("fasterFromCache"), finishWithTime(6))
+        collector.onFinish()
 
-        verify(callback, never())
+        verify(callback, never()).onSlowerFromCache(any())
     }
 
     @Test
@@ -58,8 +61,9 @@ internal class SlowerFromCacheCollectorTest {
         val callback: SlowerFromCacheCallback = mock()
         val collector = SlowerFromCacheCollector(Providers.of(0), Providers.of(callback))
         collector.onEvent(descriptorWithName("fasterFromCache"), finishWithTime(200))
+        collector.onFinish()
 
-        verify(callback, never())
+        verify(callback, never()).onSlowerFromCache(any())
     }
 
     @Test
@@ -75,8 +79,9 @@ internal class SlowerFromCacheCollectorTest {
         val callback: SlowerFromCacheCallback = mock()
         val thresholdCollector = SlowerFromCacheCollector(Providers.of(1000), Providers.of(callback))
         thresholdCollector.onEvent(descriptorWithName("longButUnderThreshold"), finishWithTime(200))
+        thresholdCollector.onFinish()
 
-        verify(callback, never())
+        verify(callback, never()).onSlowerFromCache(any())
     }
 
     @Test
@@ -92,6 +97,7 @@ internal class SlowerFromCacheCollectorTest {
         val callback: SlowerFromCacheCallback = mock()
         val thresholdCollector = SlowerFromCacheCollector(Providers.of(1000), Providers.of(callback))
         thresholdCollector.onEvent(descriptorWithName("fasterFromCacheAboveThreshold"), finishWithTime(10, 1020))
+        thresholdCollector.onFinish()
 
         verify(callback).onSlowerFromCache(listOf("fasterFromCacheAboveThreshold"))
     }


### PR DESCRIPTION
Added a new `slowerFromCacheCallback` property to the extension, so the plugin users can listen for negative savings tasks and track them.

**This is not working, I would need help.**

`slowerFromCacheCallback.orNull` is always returning null inside the `SlowerFromCacheCollector` class. Not sure why 