### PR TITLE
Fix typo on jetifier warning output in JetifierWarning.kt

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/JetifierWarning.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JetifierWarning.kt
@@ -18,7 +18,7 @@ class JetifierWarning(private val doctorExtension: DoctorExtension, private val 
 
                 To disable this warning, configure the Gradle Doctor extension:
                 doctor {
-                  warnWhenJetifierEnable.set(false)
+                  warnWhenJetifierEnabled.set(false)
                 }
                 """.trimIndent()
             )

--- a/doctor-plugin/src/test/java/com/osacky/doctor/JetifierWarningTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/JetifierWarningTest.kt
@@ -11,7 +11,7 @@ class JetifierWarningTest {
     @get:Rule
     val testProjectRoot = TemporaryFolder()
 
-    val jetifierWarning = "Jetifier was enabled which means your builds are slower by 4-20%."
+    private val jetifierWarning = "Jetifier was enabled which means your builds are slower by 4-20%."
 
     @Test
     fun testJetifierEnabledShowsWarning() {
@@ -37,9 +37,22 @@ class JetifierWarningTest {
             .withProjectDir(testProjectRoot.root)
             .build()
 
-        assertThat(result.output).contains("BUILD SUCCESSFUL")
-        assertThat(result.output).contains("Gradle Doctor Prescriptions")
-        assertThat(result.output).contains(jetifierWarning)
+        assertThat(result.output).contains(
+            """
+                =============================== Gradle Doctor Prescriptions ============================================
+                | Jetifier was enabled which means your builds are slower by 4-20%.                                    |
+                | Here's an article to help you disable it:                                                            |
+                | https://adambennett.dev/2020/08/disabling-jetifier/                                                  |
+                |                                                                                                      |
+                | To disable this warning, configure the Gradle Doctor extension:                                      |
+                | doctor {                                                                                             |
+                |   warnWhenJetifierEnabled.set(false)                                                                 |
+                | }                                                                                                    |
+                ========================================================================================================
+
+                BUILD SUCCESSFUL
+            """.trimIndent()
+        )
     }
 
     @Test


### PR DESCRIPTION
As per my [issue](https://github.com/runningcode/gradle-doctor/issues/156), this will update the console output to prescribe the correct gradle config statement to disable the jetifier. 

Updated the test to assert the console output block as it was not explicit enough to fail on my change.