### PR TITLE
Use java.specification.version for java version

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaGCFlagChecker.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaGCFlagChecker.kt
@@ -40,7 +40,7 @@ class JavaGCFlagChecker(
      * There is no straightforward Java version API in Java 8.
      */
     private fun getJavaVersion(): Int {
-        var version = System.getProperty("java.version")
+        var version = System.getProperty("java.specification.version")
         if (version.startsWith("1.")) {
             version = version.substring(2, 3)
         } else {


### PR DESCRIPTION
This is the actual specification of Java that the current JDK is running for rather than using the pedantic java.version. See https://stackoverflow.com/a/5103166 for more information

Resolves #168