### PR TITLE
Remove extraneous backticks in docs

### DIFF
--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -16,7 +16,7 @@ To force tasks to rerun for the benchmark, use `-PrerunSourceTasksForBenchmark` 
 
 Example full benchmark scenario:
 ``` bash
-./gradlew :app:assembleDebug -PbenchmarkRemoteCache -PrerunSourceTasksForBenchmark -PrerunLargeOutputTasksForBenchmark`
+./gradlew :app:assembleDebug -PbenchmarkRemoteCache -PrerunSourceTasksForBenchmark -PrerunLargeOutputTasksForBenchmark
 ```
 
 
@@ -30,7 +30,7 @@ tasks.withType(SourceTask).configureEach {
 
 Then run the specific benchmark scenario like so:
 ``` bash
-./gradlew :app:assembleDebug -PbenchmarkRemoteCache`
+./gradlew :app:assembleDebug -PbenchmarkRemoteCache
 ```
 
 


### PR DESCRIPTION
Just a very minor change to remove some extra backticks from the remote cache docs that break the copy functionality when viewed from https://runningcode.github.io/gradle-doctor/remote-cache/.