### PR TITLE
Print project name in prescriptions title for clarity's sake

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -46,7 +46,7 @@ class DoctorPlugin : Plugin<Project> {
         val os: OperatingSystem = DefaultNativePlatform.getCurrentOperatingSystem()
         val clock: Clock = SystemClock()
         val intervalMeasurer = IntervalMeasurer()
-        val pillBoxPrinter = PillBoxPrinter(target.logger)
+        val pillBoxPrinter = PillBoxPrinter(target.logger, target.displayName)
         val daemonChecker = BuildDaemonChecker(extension, createDaemonChecker(os), pillBoxPrinter)
         val javaHomeCheck = JavaHomeCheck(extension, pillBoxPrinter)
         val garbagePrinter = GarbagePrinter(clock, DirtyBeanCollector(), extension)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/PillBoxPrinter.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/PillBoxPrinter.kt
@@ -5,7 +5,7 @@ import org.gradle.api.logging.Logger
 /**
  * Prints strings inside a nicely fitted pill box.
  */
-class PillBoxPrinter(private val logger: Logger) {
+class PillBoxPrinter(private val logger: Logger, private val projectDisplayName: String) {
 
     private val messageLength = 100
     private val title = "Gradle Doctor Prescriptions"
@@ -22,7 +22,8 @@ class PillBoxPrinter(private val logger: Logger) {
     }
 
     private fun createTitle(lineLength: Int): String {
-        return " $title ".padStart(lineLength / 2 + 10, '=').padEnd(lineLength + 4, '=')
+        val text = " $title for project $projectDisplayName "
+        return "$text".padStart(lineLength / 2 + text.length / 2, '=').padEnd(lineLength + 4, '=')
     }
 
     private fun createEnding(lineLength: Int): String {

--- a/doctor-plugin/src/test/java/com/osacky/doctor/internal/PillBoxPrinterTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/internal/PillBoxPrinterTest.kt
@@ -9,7 +9,8 @@ import org.junit.Test
 internal class PillBoxPrinterTest {
 
     private val logger: Logger = mock()
-    private val underTest = PillBoxPrinter(logger)
+    private val projectDisplayName = "Test"
+    private val underTest = PillBoxPrinter(logger, projectDisplayName)
 
     @Test
     fun printSingleMessage() {
@@ -22,7 +23,7 @@ internal class PillBoxPrinterTest {
 
         underTest.writePrescription(listOf(message))
         logger.inOrder {
-            verify().warn("=============================== Gradle Doctor Prescriptions ============================================")
+            verify().warn("=========================== Gradle Doctor Prescriptions for project Test ===============================")
             verify().warn(
                 """
                                 || This is the message.                                                                                 |
@@ -50,7 +51,7 @@ internal class PillBoxPrinterTest {
         """.trimMargin()
         underTest.writePrescription(listOf(messageOne, messageTwo))
         logger.inOrder {
-            verify().warn("=============================== Gradle Doctor Prescriptions ============================================")
+            verify().warn("=========================== Gradle Doctor Prescriptions for project Test ===============================")
             verify().warn(
                 """
                                 || This is the message.                                                                                 |
@@ -78,7 +79,7 @@ internal class PillBoxPrinterTest {
         """.trimMargin()
         underTest.writePrescription(listOf(longMessage))
         logger.inOrder {
-            verify().warn("=============================== Gradle Doctor Prescriptions ============================================")
+            verify().warn("=========================== Gradle Doctor Prescriptions for project Test ===============================")
             verify().warn(
                 """
                                 || This is a really long message that will overflow from one line on to the other and looks really bad  |


### PR DESCRIPTION
The motivation behind this is [contained in a github issue](https://github.com/runningcode/gradle-doctor/issues/199)

As a quick TL;DR, for repositories that have multiple independent included builds that each have the doctor plugin applied to them, scanning the prescriptions at the end of the console output can be confusing. I'd like some clarity on which project that the plugin is prescribing changes/fixes for. 

I rely on the project's display name here, which should almost always be defined. We can use a path instead, but it may not be as readable for some users. 