### PR TITLE
Implement Apple Rosetta translation check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.withType(Test::class.java).configureEach {
 }
 
 tasks.wrapper {
-  gradleVersion = "7.4.2"
+  gradleVersion = "7.5"
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.withType(Test::class.java).configureEach {
 }
 
 tasks.wrapper {
-  gradleVersion = "7.5"
+  gradleVersion = "7.5.1"
 }
 
 buildScan {

--- a/doctor-plugin/src/main/java/com/osacky/doctor/AppleRosettaTranslationCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/AppleRosettaTranslationCheck.kt
@@ -1,0 +1,38 @@
+package com.osacky.doctor
+
+import com.osacky.doctor.internal.CliCommandExecutor
+import com.osacky.doctor.internal.PillBoxPrinter
+import org.gradle.api.GradleException
+import org.gradle.nativeplatform.platform.OperatingSystem
+import org.jetbrains.kotlin.com.google.common.annotations.VisibleForTesting
+
+class AppleRosettaTranslationCheck(
+    private val os: OperatingSystem,
+    private val cliCommandExecutor: CliCommandExecutor,
+    private val pillBoxPrinter: PillBoxPrinter,
+) : BuildStartFinishListener {
+
+    @VisibleForTesting
+    val isTranslatedCheckCommand = arrayOf("/bin/bash", "-c", "sysctl sysctl.proc_translated")
+
+    @VisibleForTesting
+    val translatedWithRosetta = "sysctl.proc_translated: 1"
+
+    @VisibleForTesting
+    val errorMessage =
+        "Attempt to run Gradle under Apple Silicon Rosetta translation. Make sure Gradle uses JDK for aarch64 architecture."
+
+    override fun onStart() {
+        if (!os.isMacOsX) return
+        val output = runCatching {
+            cliCommandExecutor.execute(isTranslatedCheckCommand)
+        }.getOrNull()
+        if (output == translatedWithRosetta) {
+            throw GradleException(pillBoxPrinter.createPill(errorMessage))
+        }
+    }
+
+    override fun onFinish(): List<String> {
+        return emptyList()
+    }
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -1,6 +1,17 @@
 package com.osacky.doctor
 
-import com.osacky.doctor.internal.*
+import com.osacky.doctor.internal.CliCommandExecutor
+import com.osacky.doctor.internal.Clock
+import com.osacky.doctor.internal.DaemonChecker
+import com.osacky.doctor.internal.DirtyBeanCollector
+import com.osacky.doctor.internal.FRESH_DAEMON
+import com.osacky.doctor.internal.IntervalMeasurer
+import com.osacky.doctor.internal.PillBoxPrinter
+import com.osacky.doctor.internal.SystemClock
+import com.osacky.doctor.internal.UnixDaemonChecker
+import com.osacky.doctor.internal.UnsupportedOsDaemonChecker
+import com.osacky.doctor.internal.farthestEmptyParent
+import com.osacky.doctor.internal.shouldUseCoCaClasses
 import com.osacky.tagger.ScanApi
 import org.gradle.api.Action
 import org.gradle.api.GradleException

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -1,16 +1,6 @@
 package com.osacky.doctor
 
-import com.osacky.doctor.internal.Clock
-import com.osacky.doctor.internal.DaemonChecker
-import com.osacky.doctor.internal.DirtyBeanCollector
-import com.osacky.doctor.internal.FRESH_DAEMON
-import com.osacky.doctor.internal.IntervalMeasurer
-import com.osacky.doctor.internal.PillBoxPrinter
-import com.osacky.doctor.internal.SystemClock
-import com.osacky.doctor.internal.UnixDaemonChecker
-import com.osacky.doctor.internal.UnsupportedOsDaemonChecker
-import com.osacky.doctor.internal.farthestEmptyParent
-import com.osacky.doctor.internal.shouldUseCoCaClasses
+import com.osacky.doctor.internal.*
 import com.osacky.tagger.ScanApi
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -41,7 +31,7 @@ class DoctorPlugin : Plugin<Project> {
         val extension = target.extensions.create<DoctorExtension>("doctor")
 
         val os: OperatingSystem = DefaultNativePlatform.getCurrentOperatingSystem()
-        val cliCommandExecutor = CliCommandExecutor()
+        val cliCommandExecutor = CliCommandExecutor(target)
         val clock: Clock = SystemClock()
         val intervalMeasurer = IntervalMeasurer()
         val pillBoxPrinter = PillBoxPrinter(target.logger)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
@@ -1,13 +1,35 @@
 package com.osacky.doctor.internal
 
 import org.gradle.api.Project
+import org.gradle.util.GradleVersion
+import java.io.InputStream
 
 class CliCommandExecutor(private val project: Project) {
 
-    @Suppress("UnstableApiUsage")
     fun execute(command: Array<String>): String {
+        return if (GradleVersion.current() >= GradleVersion.version("7.5")) {
+            executeWithConfigCacheSupport(command)
+        } else {
+            executeInLegacyWay(command)
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun executeWithConfigCacheSupport(command: Array<String>): String {
         return project.providers.exec {
             commandLine(*command)
         }.standardOutput.asText.get().trim()
+    }
+
+    private fun executeInLegacyWay(command: Array<String>): String {
+        fun InputStream.readToString() = use {
+            it.readBytes().toString(Charsets.UTF_8).trim()
+        }
+
+        val process = Runtime.getRuntime().exec(command)
+        if (process.waitFor() != 0) {
+            throw RuntimeException(process.errorStream.readToString())
+        }
+        return process.inputStream.readToString()
     }
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
@@ -1,18 +1,13 @@
 package com.osacky.doctor.internal
 
-import java.io.InputStream
+import org.gradle.api.Project
 
-class CliCommandExecutor {
+class CliCommandExecutor(private val project: Project) {
 
+    @Suppress("UnstableApiUsage")
     fun execute(command: Array<String>): String {
-        val process = Runtime.getRuntime().exec(command)
-        if (process.waitFor() != 0) {
-            throw RuntimeException(process.errorStream.readToString())
-        }
-        return process.inputStream.readToString()
-    }
-
-    private fun InputStream.readToString() = use {
-        it.readBytes().toString(Charsets.UTF_8).trim()
+        return project.providers.exec {
+            commandLine(*command)
+        }.standardOutput.asText.get().trim()
     }
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
@@ -1,0 +1,18 @@
+package com.osacky.doctor.internal
+
+import java.io.InputStream
+
+class CliCommandExecutor {
+
+    fun execute(command: Array<String>): String {
+        val process = Runtime.getRuntime().exec(command)
+        if (process.waitFor() != 0) {
+            throw RuntimeException(process.errorStream.readToString())
+        }
+        return process.inputStream.readToString()
+    }
+
+    private fun InputStream.readToString() = use {
+        it.readBytes().toString(Charsets.UTF_8).trim()
+    }
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/UnixDaemonChecker.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/UnixDaemonChecker.kt
@@ -1,8 +1,6 @@
 package com.osacky.doctor.internal
 
-import java.io.InputStream
-
-class UnixDaemonChecker : DaemonChecker {
+class UnixDaemonChecker(private val cliCommandExecutor: CliCommandExecutor) : DaemonChecker {
 
     override fun check(): String? {
         val numberOfDaemons = numberOfDaemons()
@@ -27,19 +25,7 @@ class UnixDaemonChecker : DaemonChecker {
     }
 
     private fun numberOfDaemons(): Int {
-        return arrayOf("/bin/bash", "-c", "ps aux | grep GradleDaemon | wc -l").execute().toInt() - 2
-    }
-
-    private fun Array<String>.execute(): String {
-        val process = Runtime.getRuntime().exec(this)
-        if (process.waitFor() != 0) {
-            throw RuntimeException(process.errorStream.readToString())
-        }
-
-        return process.inputStream.readToString()
-    }
-
-    private fun InputStream.readToString() = use {
-        it.readBytes().toString(Charsets.UTF_8).trim()
+        return cliCommandExecutor
+            .execute(arrayOf("/bin/bash", "-c", "ps aux | grep GradleDaemon | wc -l")).toInt() - 2
     }
 }

--- a/doctor-plugin/src/test/java/com/osacky/doctor/AppleRosettaTranslationCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/AppleRosettaTranslationCheckTest.kt
@@ -1,6 +1,10 @@
 package com.osacky.doctor
 
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
 import com.osacky.doctor.internal.CliCommandExecutor
 import com.osacky.doctor.internal.PillBoxPrinter
 import org.gradle.api.GradleException

--- a/doctor-plugin/src/test/java/com/osacky/doctor/AppleRosettaTranslationCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/AppleRosettaTranslationCheckTest.kt
@@ -1,0 +1,67 @@
+package com.osacky.doctor
+
+import com.nhaarman.mockitokotlin2.*
+import com.osacky.doctor.internal.CliCommandExecutor
+import com.osacky.doctor.internal.PillBoxPrinter
+import org.gradle.api.GradleException
+import org.gradle.nativeplatform.platform.OperatingSystem
+import org.junit.Test
+
+class AppleRosettaTranslationCheckTest {
+
+    private val operatingSystem = mock<OperatingSystem>()
+    private val cliCommandExecutor = mock<CliCommandExecutor>()
+    private val pillBoxPrinter = mock<PillBoxPrinter>()
+
+    private val underTest = AppleRosettaTranslationCheck(operatingSystem, cliCommandExecutor, pillBoxPrinter)
+
+    @Test
+    fun testOperatingSystemCheck() {
+        underTest.onStart()
+
+        verify(operatingSystem).isMacOsX
+    }
+
+    @Test
+    fun testGradleRunsNotOnAppleNoException() {
+        whenever(operatingSystem.isMacOsX).doReturn(false)
+
+        underTest.onStart()
+
+        verifyZeroInteractions(cliCommandExecutor)
+        verifyZeroInteractions(pillBoxPrinter)
+    }
+
+    @Test(expected = GradleException::class)
+    fun testGradleRunsUnderAppleRosettaExceptionThrownWithMessage() {
+        whenever(operatingSystem.isMacOsX).doReturn(true)
+        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand))
+            .thenReturn(underTest.translatedWithRosetta)
+
+        underTest.onStart()
+
+        verify(pillBoxPrinter).createPill(underTest.errorMessage)
+    }
+
+    @Test
+    fun testGradleRunsNativelyOnAppleNoException() {
+        whenever(operatingSystem.isMacOsX).doReturn(true)
+        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand))
+            .thenReturn("sysctl.proc_translated: 0")
+
+        underTest.onStart()
+
+        verifyZeroInteractions(pillBoxPrinter)
+    }
+
+    @Test
+    fun testErrorDuringTranslationDeterminationNoException() {
+        whenever(operatingSystem.isMacOsX).doReturn(true)
+        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand))
+            .thenReturn("sysctl.proc_translated: -1")
+
+        underTest.onStart()
+
+        verifyZeroInteractions(pillBoxPrinter)
+    }
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
@@ -26,7 +26,7 @@ class PluginIntegrationTest constructor(private val version: String) {
         fun getParams(): List<String> {
             // Keep 6.0 as minimum unsupported version and 6.1 as minimum supported version.
             // Keep this list to 5 as testing against too many versions causes OOMs.
-            return listOf("6.0.1", "6.1.1", "6.5.1", "7.0", "7.3.3", "7.4", "7.5.1")
+            return listOf("6.0.1", "6.5.1", "7.0", "7.4", "7.5.1")
         }
     }
 

--- a/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
@@ -26,7 +26,7 @@ class PluginIntegrationTest constructor(private val version: String) {
         fun getParams(): List<String> {
             // Keep 6.0 as minimum unsupported version and 6.1 as minimum supported version.
             // Keep this list to 5 as testing against too many versions causes OOMs.
-            return listOf("6.0.1", "6.1.1", "6.5.1", "7.0", "7.3.3", "7.4")
+            return listOf("6.0.1", "6.1.1", "6.5.1", "7.0", "7.3.3", "7.4", "7.5")
         }
     }
 

--- a/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/PluginIntegrationTest.kt
@@ -26,7 +26,7 @@ class PluginIntegrationTest constructor(private val version: String) {
         fun getParams(): List<String> {
             // Keep 6.0 as minimum unsupported version and 6.1 as minimum supported version.
             // Keep this list to 5 as testing against too many versions causes OOMs.
-            return listOf("6.0.1", "6.1.1", "6.5.1", "7.0", "7.3.3", "7.4", "7.5")
+            return listOf("6.0.1", "6.1.1", "6.5.1", "7.0", "7.3.3", "7.4", "7.5.1")
         }
     }
 

--- a/doctor-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/doctor-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Solves: https://github.com/runningcode/gradle-doctor/issues/209

Used `sysctl.proc_translated` API via bash in order to determine if process is running under Rosetta or not according to documentation: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#Determine-Whether-Your-App-Is-Running-as-a-Translated-Binary

Additional related thought: maybe we need to make this check more generic and compare machine CPU architecture with running JDK target architecture? Something similar to: https://github.com/runningcode/gradle-doctor/issues/209#issuecomment-1132645634  As hardware for Windows or Linux may benefit from ARM architecture in the future as well (maybe already there is some variants in the market).