### PR TITLE
Compare bin subdirs of java home on root mismatch [fix 187]

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -67,9 +67,11 @@ class JavaHomeCheck(
     private fun isGradleUsingJavaHome(): Boolean {
         // Follow symlinks when checking that java home matches.
         if (environmentJavaHome != null) {
-            val gradleJavaHomeBin = gradleJavaHome.toPath().toRealPath().resolve("bin")
-            val environmentJavaHomeBin = File(environmentJavaHome).toPath().resolve("bin").toRealPath()
-            return gradleJavaHomeBin == environmentJavaHomeBin
+            val gradleJavaHomePath = gradleJavaHome.toPath()
+            val environmentJavaHomePath = File(environmentJavaHome).toPath()
+            if (gradleJavaHomePath.toRealPath() != environmentJavaHomePath.toRealPath()) {
+                return gradleJavaHomePath.toRealPath().resolve("bin") == environmentJavaHomePath.resolve("bin").toRealPath()
+            }
         }
         return false
     }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -42,8 +42,8 @@ class JavaHomeCheck(
         if (extension.javaHomeHandler.ensureJavaHomeMatches.get() && !isGradleUsingJavaHome()) {
             val message = buildString {
                 appendln("Gradle is not using JAVA_HOME.")
-                appendln("JAVA_HOME is ${environmentJavaHome?.toFile()?.toPath()?.toAbsolutePath()}")
-                appendln("Gradle is using ${gradleJavaHome.toPath().toAbsolutePath()}")
+                appendln("JAVA_HOME is ${environmentJavaHome?.toFile()?.toPath()?.toRealPath()}")
+                appendln("Gradle is using ${gradleJavaHome.toPath().toRealPath()}")
                 appendln("This can slow down your build significantly when switching from Android Studio to the terminal.")
                 appendln("To fix: Project Structure -> JDK Location.")
                 appendln("Set this to your JAVA_HOME.")
@@ -66,8 +66,10 @@ class JavaHomeCheck(
 
     private fun isGradleUsingJavaHome(): Boolean {
         // Follow symlinks when checking that java home matches.
-        if (environmentJavaHome != null && gradleJavaHome.toPath().toRealPath() == File(environmentJavaHome).toPath().toRealPath()) {
-            return true
+        if (environmentJavaHome != null) {
+            val gradleJavaHomeBin = gradleJavaHome.toPath().toRealPath().resolve("bin")
+            val environmentJavaHomeBin = File(environmentJavaHome).toPath().resolve("bin").toRealPath()
+            return gradleJavaHomeBin == environmentJavaHomeBin
         }
         return false
     }


### PR DESCRIPTION
Fixes #187 
We can take it further and resolve and compare other known java dirs ie `lib`, `jre`. However I believe `bin` is sufficient since this feature mostly cares about build reproducibility.
Sadly I don't know a good way to test it since this feature is completely environment dependent, I'm happy to add such tests if anybody have an idea how to do it though.