### PR TITLE
Revert "Compare bin subdirs of java home on root mismatch [fix 187]"

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -42,8 +42,8 @@ class JavaHomeCheck(
         if (extension.javaHomeHandler.ensureJavaHomeMatches.get() && !isGradleUsingJavaHome()) {
             val message = buildString {
                 appendln("Gradle is not using JAVA_HOME.")
-                appendln("JAVA_HOME is ${environmentJavaHome?.toFile()?.toPath()?.toRealPath()}")
-                appendln("Gradle is using ${gradleJavaHome.toPath().toRealPath()}")
+                appendln("JAVA_HOME is ${environmentJavaHome?.toFile()?.toPath()?.toAbsolutePath()}")
+                appendln("Gradle is using ${gradleJavaHome.toPath().toAbsolutePath()}")
                 appendln("This can slow down your build significantly when switching from Android Studio to the terminal.")
                 appendln("To fix: Project Structure -> JDK Location.")
                 appendln("Set this to your JAVA_HOME.")
@@ -66,12 +66,8 @@ class JavaHomeCheck(
 
     private fun isGradleUsingJavaHome(): Boolean {
         // Follow symlinks when checking that java home matches.
-        if (environmentJavaHome != null) {
-            val gradleJavaHomePath = gradleJavaHome.toPath()
-            val environmentJavaHomePath = File(environmentJavaHome).toPath()
-            if (gradleJavaHomePath.toRealPath() != environmentJavaHomePath.toRealPath()) {
-                return gradleJavaHomePath.toRealPath().resolve("bin") == environmentJavaHomePath.resolve("bin").toRealPath()
-            }
+        if (environmentJavaHome != null && gradleJavaHome.toPath().toRealPath() == File(environmentJavaHome).toPath().toRealPath()) {
+            return true
         }
         return false
     }


### PR DESCRIPTION
Reverts runningcode/gradle-doctor#240

This doesn't work. I have this issue on my local machine:

```
  | Gradle is not using JAVA_HOME.                                                                       |
  | JAVA_HOME is /Users/no/.asdf/installs/java/adoptopenjdk-11.0.11+9                                    |
  | Gradle is using /Users/no/.asdf/installs/java/adoptopenjdk-11.0.11+9                                 |
  | This can slow down your build significantly when switching from Android Studio to the terminal.      |
  | To fix: Project Structure -> JDK Location.                                                           |
  | Set this to your JAVA_HOME.
  ```
  
  See build scan here: https://scans.gradle.com/s/utvdqanc3oila