### PR TITLE
fix: correct inverted syntax

### DIFF
--- a/docs/slower-from-cache.md
+++ b/docs/slower-from-cache.md
@@ -30,13 +30,13 @@ Tasks that move compressed images like pngs, jpegs, or precomputed libraries are
 
 === "Groovy"
     ``` groovy
-    tasks.named("<taskname>").configure {
+    tasks.named('<taskname>').configure {
         outputs.cacheIf { false }
     }
     ```
 === "Kotlin"
     ``` kotlin
-    tasks.named('<taskname>').configure {
+    tasks.named("<taskname>").configure {
         outputs.cacheIf { false }
     }
     ```


### PR DESCRIPTION
The groovy and kotlin examples where inverted