### PR TITLE
fix: Ignore process exit value for Apple Rosetta check

### DIFF
--- a/.github/workflows/gradle-macos-check.yml
+++ b/.github/workflows/gradle-macos-check.yml
@@ -1,0 +1,16 @@
+name: "Check plugin on MacOS"
+on: [push, pull_request]
+jobs:
+  validation:
+    name: "MacOS check"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/gradle-build-action@v2
+        name: Check Gradle Doctor
+        with:
+          arguments: pluginTasks

--- a/doctor-plugin/src/main/java/com/osacky/doctor/AppleRosettaTranslationCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/AppleRosettaTranslationCheck.kt
@@ -25,7 +25,7 @@ class AppleRosettaTranslationCheck(
         if (!os.isMacOsX) return
         val output =
             runCatching {
-                cliCommandExecutor.execute(isTranslatedCheckCommand)
+                cliCommandExecutor.execute(isTranslatedCheckCommand, ignoreExitValue = true)
             }.getOrNull()
         if (output == translatedWithRosetta) {
             throw GradleException(pillBoxPrinter.createPill(errorMessage))

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
@@ -5,7 +5,10 @@ import org.gradle.util.GradleVersion
 import java.io.InputStream
 
 class CliCommandExecutor(private val project: Project) {
-    fun execute(command: Array<String>, ignoreExitValue: Boolean = false): String {
+    fun execute(
+        command: Array<String>,
+        ignoreExitValue: Boolean = false,
+    ): String {
         return if (GradleVersion.current() >= GradleVersion.version("7.5")) {
             executeWithConfigCacheSupport(command, ignoreExitValue)
         } else {
@@ -14,14 +17,20 @@ class CliCommandExecutor(private val project: Project) {
     }
 
     @Suppress("UnstableApiUsage")
-    private fun executeWithConfigCacheSupport(command: Array<String>, ignoreExitValue: Boolean = false): String {
+    private fun executeWithConfigCacheSupport(
+        command: Array<String>,
+        ignoreExitValue: Boolean = false,
+    ): String {
         return project.providers.exec {
             commandLine(*command)
             isIgnoreExitValue = ignoreExitValue
         }.standardOutput.asText.get().trim()
     }
 
-    private fun executeInLegacyWay(command: Array<String>, ignoreExitValue: Boolean = false): String {
+    private fun executeInLegacyWay(
+        command: Array<String>,
+        ignoreExitValue: Boolean = false,
+    ): String {
         fun InputStream.readToString() =
             use {
                 it.readBytes().toString(Charsets.UTF_8).trim()

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/CliCommandExecutor.kt
@@ -5,31 +5,34 @@ import org.gradle.util.GradleVersion
 import java.io.InputStream
 
 class CliCommandExecutor(private val project: Project) {
-    fun execute(command: Array<String>): String {
+    fun execute(command: Array<String>, ignoreExitValue: Boolean = false): String {
         return if (GradleVersion.current() >= GradleVersion.version("7.5")) {
-            executeWithConfigCacheSupport(command)
+            executeWithConfigCacheSupport(command, ignoreExitValue)
         } else {
-            executeInLegacyWay(command)
+            executeInLegacyWay(command, ignoreExitValue)
         }
     }
 
     @Suppress("UnstableApiUsage")
-    private fun executeWithConfigCacheSupport(command: Array<String>): String {
+    private fun executeWithConfigCacheSupport(command: Array<String>, ignoreExitValue: Boolean = false): String {
         return project.providers.exec {
             commandLine(*command)
+            isIgnoreExitValue = ignoreExitValue
         }.standardOutput.asText.get().trim()
     }
 
-    private fun executeInLegacyWay(command: Array<String>): String {
+    private fun executeInLegacyWay(command: Array<String>, ignoreExitValue: Boolean = false): String {
         fun InputStream.readToString() =
             use {
                 it.readBytes().toString(Charsets.UTF_8).trim()
             }
 
         val process = Runtime.getRuntime().exec(command)
-        if (process.waitFor() != 0) {
-            throw RuntimeException(process.errorStream.readToString())
+        val processExitValue = process.waitFor()
+
+        return when {
+            (processExitValue == 0) || ignoreExitValue -> process.inputStream.readToString()
+            else -> throw RuntimeException(process.errorStream.readToString())
         }
-        return process.inputStream.readToString()
     }
 }

--- a/doctor-plugin/src/test/java/com/osacky/doctor/AppleRosettaTranslationCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/AppleRosettaTranslationCheckTest.kt
@@ -38,7 +38,7 @@ class AppleRosettaTranslationCheckTest {
     @Test(expected = GradleException::class)
     fun testGradleRunsUnderAppleRosettaExceptionThrownWithMessage() {
         whenever(operatingSystem.isMacOsX).doReturn(true)
-        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand))
+        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand, true))
             .thenReturn(underTest.translatedWithRosetta)
 
         underTest.onStart()
@@ -49,7 +49,7 @@ class AppleRosettaTranslationCheckTest {
     @Test
     fun testGradleRunsNativelyOnAppleNoException() {
         whenever(operatingSystem.isMacOsX).doReturn(true)
-        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand))
+        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand, true))
             .thenReturn("sysctl.proc_translated: 0")
 
         underTest.onStart()
@@ -60,7 +60,7 @@ class AppleRosettaTranslationCheckTest {
     @Test
     fun testErrorDuringTranslationDeterminationNoException() {
         whenever(operatingSystem.isMacOsX).doReturn(true)
-        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand))
+        whenever(cliCommandExecutor.execute(underTest.isTranslatedCheckCommand, true))
             .thenReturn("sysctl.proc_translated: -1")
 
         underTest.onStart()


### PR DESCRIPTION
When running the Apple Rosetta check on an Intel MacOS machine, the sysctl command exists with non-success result value.

That case is correctly handled in the check logic but breaks Gradle configuration cache as the command output is an Exception.

It should be enough to ignore the exit value of the process to restore the configuration cache usage.