### PR TITLE
Add dependency submission workflow (and fix a vulnerability)

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,0 +1,20 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+    - master
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - uses: gradle/actions/dependency-submission@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,20 @@
 import com.osacky.doctor.DoctorExtension
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+// Upgrade transitive dependencies in plugin classpath
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        constraints {
+            // The plugin com.github.ben-manes.versions:0.51.0 has dependency on com.squareup.okio:okio:3.2.0
+            // which has reported vulnerability CVE-2023-3635. Use a newer version.
+            classpath(libs.okio)
+        }
+    }
+}
+
 plugins {
   alias(libs.plugins.kgp)
   alias(libs.plugins.versions)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ truth = "com.google.truth:truth:1.3.0"
 tagger = "com.osacky.tagger:tagger-lib:0.2"
 rxjava = "io.reactivex.rxjava3:rxjava:3.1.8"
 mockito = "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+okio = "com.squareup.okio:okio:3.4.0"
 
 [plugins]
 kgp = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
- Adds dependency graph workflow using `gradle/actions/dependency-submission`.
- Fixes a reported vulnerability by upgrading transitive dependency in plugin classpath.