### PR TITLE
Added support for zulu like jdks by performing the java home check based on bin(executables folder).

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -9,8 +9,8 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         java-version: |
-          '17'
-          '8'
+          17
+          8
         distribution: 'temurin'
     - uses: gradle/actions/setup-gradle@v3
       with:

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -8,7 +8,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: |
+          '17'
+          '8'
         distribution: 'temurin'
     - uses: gradle/actions/setup-gradle@v3
       with:

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -11,7 +11,7 @@ jobs:
         java-version: |
           17
           8
-        distribution: 'temurin'
+        distribution: 'liberica'
     - uses: gradle/actions/setup-gradle@v3
       with:
         add-job-summary-as-pr-comment: on-failure

--- a/.github/workflows/gradle-macos-check.yml
+++ b/.github/workflows/gradle-macos-check.yml
@@ -11,7 +11,7 @@ jobs:
           java-version: |
             8
             17
-          distribution: 'temurin'
+          distribution: 'liberica'
       - uses: gradle/actions/setup-gradle@v3
         with:
           add-job-summary-as-pr-comment: on-failure

--- a/.github/workflows/gradle-macos-check.yml
+++ b/.github/workflows/gradle-macos-check.yml
@@ -8,7 +8,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: |
+            '8'
+            '17'
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/gradle-macos-check.yml
+++ b/.github/workflows/gradle-macos-check.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: |
-            '8'
-            '17'
+            8
+            17
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v3
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,8 @@ configure<DoctorExtension> {
   downloadSpeedWarningThreshold.set(2.0f)
   daggerThreshold.set(100)
   javaHome {
-    ensureJavaHomeMatches.set(false)
-      ensureJavaHomeIsSet.set(false)
+      ensureJavaHomeMatches.set(true)
+      ensureJavaHomeIsSet.set(true)
   }
 }
 

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -164,13 +164,7 @@ class DoctorPlugin : Plugin<Project> {
     ): JavaHomeCheck {
         val jvmVariables =
             JvmVariables(environmentJavaHome = System.getenv(JAVA_HOME), gradleJavaHome = Jvm.current().javaHome.path)
-        val javaHomeCheckConfig = JavaHomeCheckConfig(
-            ensureJavaHomeIsSet = extension.javaHomeHandler.ensureJavaHomeIsSet.get(),
-            ensureJavaHomeMatches = extension.javaHomeHandler.ensureJavaHomeMatches.get(),
-            extraMessage = extension.javaHomeHandler.extraMessage.orNull,
-            failOnError = extension.javaHomeHandler.failOnError.get()
-        )
-        return JavaHomeCheck(jvmVariables, javaHomeCheckConfig, pillBoxPrinter)
+        return JavaHomeCheck(jvmVariables, extension, pillBoxPrinter)
     }
 
     private fun tagFreshDaemon(

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -160,7 +160,7 @@ class DoctorPlugin : Plugin<Project> {
 
     private fun createJavaHomeCheck(
         extension: DoctorExtension,
-        pillBoxPrinter: PillBoxPrinter
+        pillBoxPrinter: PillBoxPrinter,
     ): JavaHomeCheck {
         val jvmVariables =
             JvmVariables(environmentJavaHome = System.getenv(JAVA_HOME), gradleJavaHome = Jvm.current().javaHome.path)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -164,7 +164,7 @@ class DoctorPlugin : Plugin<Project> {
     ): JavaHomeCheck {
         val jvmVariables =
             JvmVariables(environmentJavaHome = System.getenv(JAVA_HOME), gradleJavaHome = Jvm.current().javaHome.path)
-        return JavaHomeCheck(jvmVariables, extension, pillBoxPrinter)
+        return JavaHomeCheck(jvmVariables, extension.javaHomeHandler, pillBoxPrinter)
     }
 
     private fun tagFreshDaemon(

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -9,7 +9,8 @@ import org.gradle.api.GradleException
 import java.io.File
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.util.*
+import java.util.Collections
+import kotlin.collections.LinkedHashSet
 import kotlin.io.path.exists
 import kotlin.io.path.pathString
 

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -1,7 +1,7 @@
 package com.osacky.doctor
 
-import com.osacky.doctor.internal.DefaultPrescriptionGenerator
 import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter
+import com.osacky.doctor.internal.DefaultPrescriptionGenerator
 import com.osacky.doctor.internal.JAVA_HOME_TAG
 import com.osacky.doctor.internal.JavaHomeCheckPrescriptionsGenerator
 import com.osacky.doctor.internal.PillBoxPrinter
@@ -22,9 +22,9 @@ class JavaHomeCheck(
     jvmVariables: JvmVariables,
     private val javaHomeHandler: JavaHomeHandler,
     private val pillBoxPrinter: PillBoxPrinter,
-    private val prescriptionsGenerator: JavaHomeCheckPrescriptionsGenerator = DefaultPrescriptionGenerator { javaHomeHandler.extraMessage.orNull }
+    private val prescriptionsGenerator: JavaHomeCheckPrescriptionsGenerator =
+        DefaultPrescriptionGenerator { javaHomeHandler.extraMessage.orNull },
 ) : BuildStartFinishListener, HasBuildScanTag {
-
     private val gradleJavaExecutablePath by lazy { resolveExecutableJavaPath(jvmVariables.gradleJavaHome) }
     private val environmentJavaExecutablePath by lazy { resolveEnvironmentJavaHome(jvmVariables.environmentJavaHome) }
     private val recordedErrors = Collections.synchronizedSet(LinkedHashSet<String>())
@@ -55,8 +55,8 @@ class JavaHomeCheck(
             failOrRecordMessage(
                 prescriptionsGenerator.generateJavaHomeMismatchesGradleHome(
                     environmentJavaExecutablePath?.pathString,
-                    gradleJavaExecutablePath.pathString
-                )
+                    gradleJavaExecutablePath.pathString,
+                ),
             )
         }
     }
@@ -69,22 +69,26 @@ class JavaHomeCheck(
         }
     }
 
-    private fun resolveEnvironmentJavaHome(location: String?) = location?.let {
-        resolveExecutableJavaPath(it) { path ->
-            if (!path.exists()) {
-                throw GradleException(String.format(JAVA_HOME_NOT_FOUND, path))
+    private fun resolveEnvironmentJavaHome(location: String?) =
+        location?.let {
+            resolveExecutableJavaPath(it) { path ->
+                if (!path.exists()) {
+                    throw GradleException(String.format(JAVA_HOME_NOT_FOUND, path))
+                }
+                return@resolveExecutableJavaPath path
             }
-            return@resolveExecutableJavaPath path
         }
-    }
 
-    private fun resolveExecutableJavaPath(location: String, fallback: (Path) -> Path = { it }): Path {
+    private fun resolveExecutableJavaPath(
+        location: String,
+        fallback: (Path) -> Path = { it },
+    ): Path {
         val path = File(location).toPath()
         return try {
             // Follow symlinks when checking that java home matches.
             path.resolve(JAVA_EXECUTABLES_FOLDER).toRealPath()
         } catch (exc: NoSuchFileException) {
-            //fallback to initial path
+            // fallback to initial path
             return fallback(path)
         }
     }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -20,9 +20,9 @@ internal const val JAVA_HOME_NOT_FOUND =
 
 class JavaHomeCheck(
     jvmVariables: JvmVariables,
-    private val doctorExtension: DoctorExtension,
+    private val javaHomeHandler: JavaHomeHandler,
     private val pillBoxPrinter: PillBoxPrinter,
-    private val prescriptionsGenerator: JavaHomeCheckPrescriptionsGenerator = DefaultPrescriptionGenerator { doctorExtension.javaHomeHandler.extraMessage.orNull }
+    private val prescriptionsGenerator: JavaHomeCheckPrescriptionsGenerator = DefaultPrescriptionGenerator { javaHomeHandler.extraMessage.orNull }
 ) : BuildStartFinishListener, HasBuildScanTag {
 
     private val gradleJavaExecutablePath by lazy { resolveExecutableJavaPath(jvmVariables.gradleJavaHome) }
@@ -45,13 +45,13 @@ class JavaHomeCheck(
     }
 
     private fun ensureJavaHomeIsSet() {
-        if (doctorExtension.javaHomeHandler.ensureJavaHomeIsSet.get() && environmentJavaExecutablePath == null) {
+        if (javaHomeHandler.ensureJavaHomeIsSet.get() && environmentJavaExecutablePath == null) {
             failOrRecordMessage(prescriptionsGenerator.generateJavaHomeIsNotSetMessage())
         }
     }
 
     private fun ensureJavaHomeMatchesGradleHome() {
-        if (doctorExtension.javaHomeHandler.ensureJavaHomeMatches.get() && !isGradleUsingJavaHome) {
+        if (javaHomeHandler.ensureJavaHomeMatches.get() && !isGradleUsingJavaHome) {
             failOrRecordMessage(
                 prescriptionsGenerator.generateJavaHomeMismatchesGradleHome(
                     environmentJavaExecutablePath?.pathString,
@@ -62,7 +62,7 @@ class JavaHomeCheck(
     }
 
     private fun failOrRecordMessage(message: String) {
-        if (doctorExtension.javaHomeHandler.failOnError.get()) {
+        if (javaHomeHandler.failOnError.get()) {
             throw GradleException(pillBoxPrinter.createPill(message))
         } else {
             recordedErrors.add(message)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/JavaHomeCheck.kt
@@ -1,83 +1,100 @@
 package com.osacky.doctor
 
+import com.osacky.doctor.internal.DefaultPrescriptionGenerator
 import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter
 import com.osacky.doctor.internal.JAVA_HOME_TAG
+import com.osacky.doctor.internal.JavaHomeCheckPrescriptionsGenerator
 import com.osacky.doctor.internal.PillBoxPrinter
 import org.gradle.api.GradleException
-import org.gradle.internal.jvm.Jvm
 import java.io.File
-import java.util.Collections
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.util.*
+import kotlin.io.path.exists
+import kotlin.io.path.pathString
+
+internal const val JAVA_HOME = "JAVA_HOME"
+internal const val JAVA_EXECUTABLES_FOLDER = "bin"
+internal const val JAVA_HOME_NOT_FOUND =
+    "There is no existing filesystem structure for %s. Please specify proper path for $JAVA_HOME!"
 
 class JavaHomeCheck(
-    private val extension: DoctorExtension,
+    jvmVariables: JvmVariables,
+    private val config: JavaHomeCheckConfig,
     private val pillBoxPrinter: PillBoxPrinter,
+    private val prescriptionsGenerator: JavaHomeCheckPrescriptionsGenerator = DefaultPrescriptionGenerator(config.extraMessage)
 ) : BuildStartFinishListener, HasBuildScanTag {
-    private val environmentJavaHome: String? = System.getenv("JAVA_HOME")
-    private val gradleJavaHome = Jvm.current().javaHome
+
+    private val gradleJavaExecutablePath by lazy { resolveExecutableJavaPath(jvmVariables.gradleJavaHome) }
+    private val environmentJavaExecutablePath by lazy { resolveEnvironmentJavaHome(jvmVariables.environmentJavaHome) }
     private val recordedErrors = Collections.synchronizedSet(LinkedHashSet<String>())
+    private val isGradleUsingJavaHome: Boolean
+        get() = gradleJavaExecutablePath == environmentJavaExecutablePath
 
     override fun onStart() {
-        val extraMessage = extension.javaHomeHandler.extraMessage.orNull
-        val failOnError = extension.javaHomeHandler.failOnError.get()
-
-        if (extension.javaHomeHandler.ensureJavaHomeIsSet.get() && environmentJavaHome == null) {
-            val message =
-                buildString {
-                    appendln("JAVA_HOME is not set.")
-                    appendln(
-                        "Please set JAVA_HOME so that switching between Android Studio and the terminal does not trigger a full rebuild.",
-                    )
-                    appendln("To set JAVA_HOME: (using bash)")
-                    appendln("echo \"export JAVA_HOME=${'$'}(/usr/libexec/java_home)\" >> ~/.bash_profile")
-                    appendln("or `~/.zshrc` if using zsh.")
-                    extraMessage?.let {
-                        appendln()
-                        appendln(extraMessage)
-                    }
-                }
-            if (failOnError) {
-                throw GradleException(pillBoxPrinter.createPill(message))
-            } else {
-                recordedErrors.add(message)
-            }
-        }
-        if (extension.javaHomeHandler.ensureJavaHomeMatches.get() && !isGradleUsingJavaHome()) {
-            val message =
-                buildString {
-                    appendln("Gradle is not using JAVA_HOME.")
-                    appendln("JAVA_HOME is ${environmentJavaHome?.toFile()?.toPath()?.toAbsolutePath()}")
-                    appendln("Gradle is using ${gradleJavaHome.toPath().toAbsolutePath()}")
-                    appendln("This can slow down your build significantly when switching from Android Studio to the terminal.")
-                    appendln("To fix: Project Structure -> JDK Location.")
-                    appendln("Set this to your JAVA_HOME.")
-                    extraMessage?.let {
-                        appendln()
-                        appendln(extraMessage)
-                    }
-                }
-            if (failOnError) {
-                throw GradleException(pillBoxPrinter.createPill(message))
-            } else {
-                recordedErrors.add(message)
-            }
-        }
+        ensureJavaHomeIsSet()
+        ensureJavaHomeMatchesGradleHome()
     }
 
     override fun onFinish(): List<String> {
         return recordedErrors.toList()
     }
 
-    private fun isGradleUsingJavaHome(): Boolean {
-        // Follow symlinks when checking that java home matches.
-        if (environmentJavaHome != null && gradleJavaHome.toPath().toRealPath() == File(environmentJavaHome).toPath().toRealPath()) {
-            return true
-        }
-        return false
-    }
-
-    private fun String.toFile() = File(this)
-
     override fun addCustomValues(buildScanApi: BuildScanAdapter) {
         buildScanApi.tag(JAVA_HOME_TAG)
     }
+
+    private fun ensureJavaHomeIsSet() {
+        if (config.ensureJavaHomeIsSet && environmentJavaExecutablePath == null) {
+            failOrRecordMessage(prescriptionsGenerator.generateJavaHomeIsNotSetMessage())
+        }
+    }
+
+    private fun ensureJavaHomeMatchesGradleHome() {
+        if (config.ensureJavaHomeMatches && !isGradleUsingJavaHome) {
+            failOrRecordMessage(
+                prescriptionsGenerator.generateJavaHomeMismatchesGradleHome(
+                    environmentJavaExecutablePath?.pathString,
+                    gradleJavaExecutablePath.pathString
+                )
+            )
+        }
+    }
+
+    private fun failOrRecordMessage(message: String) {
+        if (config.failOnError) {
+            throw GradleException(pillBoxPrinter.createPill(message))
+        } else {
+            recordedErrors.add(message)
+        }
+    }
+
+    private fun resolveEnvironmentJavaHome(location: String?) = location?.let {
+        resolveExecutableJavaPath(it) { path ->
+            if (!path.exists()) {
+                throw GradleException(String.format(JAVA_HOME_NOT_FOUND, path))
+            }
+            return@resolveExecutableJavaPath path
+        }
+    }
+
+    private fun resolveExecutableJavaPath(location: String, fallback: (Path) -> Path = { it }): Path {
+        val path = File(location).toPath()
+        return try {
+            // Follow symlinks when checking that java home matches.
+            path.resolve(JAVA_EXECUTABLES_FOLDER).toRealPath()
+        } catch (exc: NoSuchFileException) {
+            //fallback to initial path
+            return fallback(path)
+        }
+    }
 }
+
+data class JvmVariables(val environmentJavaHome: String?, val gradleJavaHome: String)
+
+data class JavaHomeCheckConfig(
+    val ensureJavaHomeIsSet: Boolean,
+    val ensureJavaHomeMatches: Boolean,
+    val extraMessage: String?,
+    val failOnError: Boolean
+)

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
@@ -43,8 +43,10 @@ interface JavaHomeCheckPrescriptionsGenerator {
     fun generateJavaHomeMismatchesGradleHome(javaHomeLocation: String?, gradleJavaHomeLocation: String): String
 }
 
-internal class DefaultPrescriptionGenerator(private val extraMessage: String?) : JavaHomeCheckPrescriptionsGenerator {
-    override fun generateJavaHomeIsNotSetMessage() = String.format(NO_JAVA_HOME_MESSAGE, extraMessage).trimIndent()
+internal class DefaultPrescriptionGenerator(private val extraMessage: () -> String?) :
+    JavaHomeCheckPrescriptionsGenerator {
+    override fun generateJavaHomeIsNotSetMessage() =
+        String.format(NO_JAVA_HOME_MESSAGE, extraMessage().orEmpty()).trimIndent()
 
     override fun generateJavaHomeMismatchesGradleHome(
         javaHomeLocation: String?,
@@ -57,7 +59,7 @@ internal class DefaultPrescriptionGenerator(private val extraMessage: String?) :
             JAVA_HOME_DOESNT_MATCH_GRADLE_HOME,
             javaHomeMessage,
             gradleJavaHomeMessage,
-            extraMessage
+            extraMessage().orEmpty()
         ).trimIndent()
     }
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.osacky.doctor.internal
+
+internal const val NO_JAVA_HOME = "JAVA_HOME is not set."
+internal const val JAVA_HOME_AT_LOCATION = "JAVA_HOME is %s"
+internal const val GRADLE_JAVA_HOME_AT_LOCATION = "Gradle is using %s"
+internal const val NO_JAVA_HOME_MESSAGE = """
+    $NO_JAVA_HOME
+    Please set JAVA_HOME so that switching between Android Studio and the terminal does not trigger a full rebuild.
+    To set JAVA_HOME: (using bash)
+    echo "export JAVA_HOME=${'$'}(/usr/libexec/java_home)" >> ~/.bash_profile
+    or `~/.zshrc` if using zsh.
+    %s
+"""
+
+internal const val JAVA_HOME_DOESNT_MATCH_GRADLE_HOME = """
+    Gradle is not using JAVA_HOME.
+    %s
+    %s
+    This can slow down your build significantly when switching from Android Studio to the terminal.
+    To fix: Project Structure -> JDK Location.
+    Set this to your JAVA_HOME.
+    %s
+"""
+
+interface JavaHomeCheckPrescriptionsGenerator {
+    fun generateJavaHomeIsNotSetMessage(): String
+    fun generateJavaHomeMismatchesGradleHome(javaHomeLocation: String?, gradleJavaHomeLocation: String): String
+}
+
+internal class DefaultPrescriptionGenerator(private val extraMessage: String?) : JavaHomeCheckPrescriptionsGenerator {
+    override fun generateJavaHomeIsNotSetMessage() = String.format(NO_JAVA_HOME_MESSAGE, extraMessage).trimIndent()
+
+    override fun generateJavaHomeMismatchesGradleHome(
+        javaHomeLocation: String?,
+        gradleJavaHomeLocation: String
+    ): String {
+        val javaHomeMessage =
+            javaHomeLocation?.let { String.format(JAVA_HOME_AT_LOCATION, it) } ?: NO_JAVA_HOME
+        val gradleJavaHomeMessage = String.format(GRADLE_JAVA_HOME_AT_LOCATION, gradleJavaHomeLocation)
+        return String.format(
+            JAVA_HOME_DOESNT_MATCH_GRADLE_HOME,
+            javaHomeMessage,
+            gradleJavaHomeMessage,
+            extraMessage
+        ).trimIndent()
+    }
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
@@ -40,17 +40,20 @@ internal const val JAVA_HOME_DOESNT_MATCH_GRADLE_HOME = """
 
 interface JavaHomeCheckPrescriptionsGenerator {
     fun generateJavaHomeIsNotSetMessage(): String
-    fun generateJavaHomeMismatchesGradleHome(javaHomeLocation: String?, gradleJavaHomeLocation: String): String
+
+    fun generateJavaHomeMismatchesGradleHome(
+        javaHomeLocation: String?,
+        gradleJavaHomeLocation: String,
+    ): String
 }
 
 internal class DefaultPrescriptionGenerator(private val extraMessage: () -> String?) :
     JavaHomeCheckPrescriptionsGenerator {
-    override fun generateJavaHomeIsNotSetMessage() =
-        String.format(NO_JAVA_HOME_MESSAGE, extraMessage().orEmpty()).trimIndent()
+    override fun generateJavaHomeIsNotSetMessage() = String.format(NO_JAVA_HOME_MESSAGE, extraMessage().orEmpty()).trimIndent()
 
     override fun generateJavaHomeMismatchesGradleHome(
         javaHomeLocation: String?,
-        gradleJavaHomeLocation: String
+        gradleJavaHomeLocation: String,
     ): String {
         val javaHomeMessage =
             javaHomeLocation?.let { String.format(JAVA_HOME_AT_LOCATION, it) } ?: NO_JAVA_HOME
@@ -59,7 +62,7 @@ internal class DefaultPrescriptionGenerator(private val extraMessage: () -> Stri
             JAVA_HOME_DOESNT_MATCH_GRADLE_HOME,
             javaHomeMessage,
             gradleJavaHomeMessage,
-            extraMessage().orEmpty()
+            extraMessage().orEmpty(),
         ).trimIndent()
     }
 }

--- a/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
@@ -16,19 +16,29 @@
 
 package com.osacky.doctor
 
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.atLeast
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
 import com.osacky.doctor.internal.PillBoxPrinter
 import com.osacky.doctor.internal.SpyJavaHomePrescriptionsGenerator
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.io.path.*
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createDirectory
+import kotlin.io.path.createSymbolicLinkPointingTo
+import kotlin.io.path.pathString
 
 class JavaHomeCheckTest {
     @get:Rule
@@ -103,7 +113,7 @@ class JavaHomeCheckTest {
     }
 
     @Test(expected = GradleException::class)
-    fun `given gradle and environment java home path doesn't match when a failOnError check is performed then there is at least one prescription and an exception thrown`() {
+    fun `given paths don't match when a failOnError check is performed then there is at least one prescription and an exception thrown`() {
         val jvmVariables = setupDifferentJvmVariables()
         whenever(javaHomeHandler.failOnError).thenReturn(alwaysTrueProperty)
         underTest = JavaHomeCheck(jvmVariables, javaHomeHandler, pillBoxPrinter, spyPrescriptionsGenerator)
@@ -115,7 +125,7 @@ class JavaHomeCheckTest {
     }
 
     @Test
-    fun `given gradle and environment java home path doesn't match when a full check is performed then there is at least one prescription`() {
+    fun `given paths don't match when a full check is performed then there is at least one prescription`() {
         val jvmVariables = setupDifferentJvmVariables()
         underTest = JavaHomeCheck(jvmVariables, javaHomeHandler, pillBoxPrinter, spyPrescriptionsGenerator)
         underTest.onStart()
@@ -127,7 +137,7 @@ class JavaHomeCheckTest {
     }
 
     @Test
-    fun `given gradle and environment java home matches when a full check is performed then there are no prescriptions`() {
+    fun `given paths match when a full check is performed then there are no prescriptions`() {
         val legitJvmVariables = setupIdenticalJvmVariables()
         underTest = JavaHomeCheck(legitJvmVariables, javaHomeHandler, pillBoxPrinter)
         underTest.onStart()
@@ -138,7 +148,7 @@ class JavaHomeCheckTest {
 
     // in order to run this test successfully on windows you need to run as administrator as you need extra permissions to create symlinks
     @Test
-    fun `given zulu like java distributions(with symlinks) where gradle and environment java home matches when a full check is performed then there are no prescriptions`() {
+    fun `given zulu path(with symlink) and paths match when a full check is performed then there are no prescriptions`() {
         javaHomePath = setupJavaHomePathStructure(zuluJavaHomePathFolders)
 
         // removing 17.0.10-zulu/Contents/Home/ to reach to root Users/doctor/.sdkman/candidates/java and setup symlink

--- a/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
@@ -31,7 +31,6 @@ import java.nio.file.Paths
 import kotlin.io.path.*
 
 class JavaHomeCheckTest {
-
     @get:Rule
     val testProjectRoot = TemporaryFolder()
 
@@ -39,7 +38,9 @@ class JavaHomeCheckTest {
     private val alwaysFalseProperty = mock<Property<Boolean>>().also { whenever(it.get()).thenReturn(false) }
     private val alwaysTrueProperty = mock<Property<Boolean>>().also { whenever(it.get()).thenReturn(true) }
     private val errorMessageProperty =
-        mock<Property<String>>().also { whenever(it.get()).thenReturn("Please ensure your that your java home is set and is the same as gradle java home.") }
+        mock<Property<String>>().also {
+            whenever(it.get()).thenReturn("Please ensure your that your java home is set and is the same as gradle java home.")
+        }
 
     /**
      *  No need to test against different filesystems as this logic is entirely handled inside nio(Paths.get) framework,
@@ -56,19 +57,19 @@ class JavaHomeCheckTest {
     private val anotherLegitJavaHomePathFolders =
         arrayOf("Library", "Java", "JavaVirtualMachines", "z.y.x-jdk", *macOSContentFolderStructure)
 
-
     private val currentZuluDistributionFolder = "17.0.10-zulu"
     private val currentZuluJDKFolder = "zulu-17.jdk"
     private val zuluJDKStructure =
         arrayOf(currentZuluDistributionFolder, currentZuluJDKFolder, *macOSContentFolderStructure)
-    private val zuluJavaHomePathFolders = arrayOf(
-        "Users",
-        "doctor",
-        ".sdkman",
-        "candidates",
-        "java",
-        *zuluJDKStructure,
-    )
+    private val zuluJavaHomePathFolders =
+        arrayOf(
+            "Users",
+            "doctor",
+            ".sdkman",
+            "candidates",
+            "java",
+            *zuluJDKStructure,
+        )
 
     private lateinit var javaHomePath: Path
     private lateinit var spyPrescriptionsGenerator: SpyJavaHomePrescriptionsGenerator
@@ -91,7 +92,7 @@ class JavaHomeCheckTest {
                 jvmVariables,
                 javaHomeHandler,
                 pillBoxPrinter,
-                spyPrescriptionsGenerator
+                spyPrescriptionsGenerator,
             )
         underTest.onStart()
         val errors = underTest.onFinish()
@@ -142,28 +143,31 @@ class JavaHomeCheckTest {
 
         // removing 17.0.10-zulu/Contents/Home/ to reach to root Users/doctor/.sdkman/candidates/java and setup symlink
         val amountOfDirectoriesBeforeRootJavaFolder = zuluJDKStructure.size
-        val javaDistributionsRootFolderPath = javaHomePath.root.resolve(
-            javaHomePath.subpath(
-                0,
-                javaHomePath.count() - amountOfDirectoriesBeforeRootJavaFolder
+        val javaDistributionsRootFolderPath =
+            javaHomePath.root.resolve(
+                javaHomePath.subpath(
+                    0,
+                    javaHomePath.count() - amountOfDirectoriesBeforeRootJavaFolder,
+                ),
             )
-        )
 
         // creating several distributions to make it look more realistic
         val severalJavaDistributions = arrayOf("11.0.21.fx-zulu", "17.0.10-amzn", "17.0.10-oracle")
         severalJavaDistributions.forEach {
             javaDistributionsRootFolderPath.resolve(it).createDirectory()
         }
-        val zuluRootFolderPath = javaHomePath.root.resolve(
-            javaHomePath.subpath(
-                0,
-                javaHomePath.count() - (amountOfDirectoriesBeforeRootJavaFolder - 1)
+        val zuluRootFolderPath =
+            javaHomePath.root.resolve(
+                javaHomePath.subpath(
+                    0,
+                    javaHomePath.count() - (amountOfDirectoriesBeforeRootJavaFolder - 1),
+                ),
             )
-        )
 
         // creating the sdkman "current" symlink and pointing to zulu
-        val sdkmanEnvironmentJavaHome = javaDistributionsRootFolderPath.resolve("current")
-            .createSymbolicLinkPointingTo(zuluRootFolderPath.toAbsolutePath())
+        val sdkmanEnvironmentJavaHome =
+            javaDistributionsRootFolderPath.resolve("current")
+                .createSymbolicLinkPointingTo(zuluRootFolderPath.toAbsolutePath())
         val javaExecutableFolder = javaHomePath.resolve(JAVA_EXECUTABLES_FOLDER).createDirectories()
 
         // creating zulu bin symlink and pointing it to the actual /Contents/Home/bin folder

--- a/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.osacky.doctor
+
+import com.nhaarman.mockitokotlin2.*
+import com.osacky.doctor.internal.PillBoxPrinter
+import com.osacky.doctor.internal.SpyJavaHomePrescriptionsGenerator
+import org.gradle.api.GradleException
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.*
+
+class JavaHomeCheckTest {
+
+    @get:Rule
+    val testProjectRoot = TemporaryFolder()
+
+    private val allJavaHomeChecksEnabled = JavaHomeCheckConfig(
+        ensureJavaHomeIsSet = true,
+        ensureJavaHomeMatches = true,
+        extraMessage = "Please ensure your that your java home is set and is the same as gradle java home.",
+        failOnError = false
+    )
+
+    /**
+     *  No need to test against different filesystems as this logic is entirely handled inside nio(Paths.get) framework,
+     *  so it doesn't matter as the correct file separation char will be provided under the hood.
+     */
+    private val macOSContentFolderStructure = arrayOf("Contents", "Home")
+
+    private val legitJavaHomePathFolders =
+        arrayOf("Library", "Java", "JavaVirtualMachines", "x.y.z-jdk", *macOSContentFolderStructure)
+
+    /**
+     * Is used to simulate a different jdk path.
+     */
+    private val anotherLegitJavaHomePathFolders =
+        arrayOf("Library", "Java", "JavaVirtualMachines", "z.y.x-jdk", *macOSContentFolderStructure)
+
+
+    private val currentZuluDistributionFolder = "17.0.10-zulu"
+    private val currentZuluJDKFolder = "zulu-17.jdk"
+    private val zuluJDKStructure =
+        arrayOf(currentZuluDistributionFolder, currentZuluJDKFolder, *macOSContentFolderStructure)
+    private val zuluJavaHomePathFolders = arrayOf(
+        "Users",
+        "doctor",
+        ".sdkman",
+        "candidates",
+        "java",
+        *zuluJDKStructure,
+    )
+
+    private lateinit var javaHomePath: Path
+    private lateinit var spyPrescriptionsGenerator: SpyJavaHomePrescriptionsGenerator
+    private lateinit var underTest: JavaHomeCheck
+
+    private val pillBoxPrinter = mock<PillBoxPrinter>()
+
+    @Before
+    fun setup() {
+        javaHomePath = setupJavaHomePathStructure(legitJavaHomePathFolders)
+        spyPrescriptionsGenerator = SpyJavaHomePrescriptionsGenerator()
+    }
+
+    @Test
+    fun `given environment java home path is not set when a full check is performed then there are at least two prescriptions`() {
+        val jvmVariables = setupIdenticalJvmVariables().copy(environmentJavaHome = null)
+        val config = allJavaHomeChecksEnabled
+        underTest =
+            JavaHomeCheck(
+                jvmVariables,
+                config,
+                pillBoxPrinter,
+                spyPrescriptionsGenerator
+            )
+        underTest.onStart()
+        val errors = underTest.onFinish()
+        assertTrue(errors.size == 2)
+        assertTrue(spyPrescriptionsGenerator.noJavaHomeGenerationWasCalled)
+        assertTrue(spyPrescriptionsGenerator.javaHomeMismatchGenerationWasCalled)
+        verifyJvmVariablesAreUsedForPrescriptionGeneration(jvmVariables)
+    }
+
+    @Test(expected = GradleException::class)
+    fun `given gradle and environment java home path doesn't match when a failOnError check is performed then there is at least one prescription and an exception thrown`() {
+        val jvmVariables = setupDifferentJvmVariables()
+        val config = allJavaHomeChecksEnabled.copy(failOnError = true)
+        underTest = JavaHomeCheck(jvmVariables, config, pillBoxPrinter, spyPrescriptionsGenerator)
+        underTest.onStart()
+        assertFalse(spyPrescriptionsGenerator.noJavaHomeGenerationWasCalled)
+        assertTrue(spyPrescriptionsGenerator.javaHomeMismatchGenerationWasCalled)
+        verifyJvmVariablesAreUsedForPrescriptionGeneration(jvmVariables)
+        verify(pillBoxPrinter, atLeast(1)).createPill(any())
+    }
+
+    @Test
+    fun `given gradle and environment java home path doesn't match when a full check is performed then there is at least one prescription`() {
+        val jvmVariables = setupDifferentJvmVariables()
+        val config = allJavaHomeChecksEnabled
+        underTest = JavaHomeCheck(jvmVariables, config, pillBoxPrinter, spyPrescriptionsGenerator)
+        underTest.onStart()
+        val errors = underTest.onFinish()
+        assertTrue(errors.isNotEmpty())
+        assertFalse(spyPrescriptionsGenerator.noJavaHomeGenerationWasCalled)
+        assertTrue(spyPrescriptionsGenerator.javaHomeMismatchGenerationWasCalled)
+        verifyJvmVariablesAreUsedForPrescriptionGeneration(jvmVariables)
+    }
+
+    @Test
+    fun `given gradle and environment java home matches when a full check is performed then there are no prescriptions`() {
+        val legitJvmVariables = setupIdenticalJvmVariables()
+        underTest = JavaHomeCheck(legitJvmVariables, allJavaHomeChecksEnabled, pillBoxPrinter)
+        underTest.onStart()
+        val errors = underTest.onFinish()
+        verifyZeroInteractions(pillBoxPrinter)
+        assertTrue(errors.isEmpty())
+    }
+
+    // in order to run this test successfully on windows you need to run as administrator as you need extra permissions to create symlinks
+    @Test
+    fun `given zulu like java distributions(with symlinks) where gradle and environment java home matches when a full check is performed then there are no prescriptions`() {
+        javaHomePath = setupJavaHomePathStructure(zuluJavaHomePathFolders)
+
+        // removing 17.0.10-zulu/Contents/Home/ to reach to root Users/doctor/.sdkman/candidates/java and setup symlink
+        val amountOfDirectoriesBeforeRootJavaFolder = zuluJDKStructure.size
+        val javaDistributionsRootFolderPath = javaHomePath.root.resolve(
+            javaHomePath.subpath(
+                0,
+                javaHomePath.count() - amountOfDirectoriesBeforeRootJavaFolder
+            )
+        )
+
+        // creating several distributions to make it look more realistic
+        val severalJavaDistributions = arrayOf("11.0.21.fx-zulu", "17.0.10-amzn", "17.0.10-oracle")
+        severalJavaDistributions.forEach {
+            javaDistributionsRootFolderPath.resolve(it).createDirectory()
+        }
+        val zuluRootFolderPath = javaHomePath.root.resolve(
+            javaHomePath.subpath(
+                0,
+                javaHomePath.count() - (amountOfDirectoriesBeforeRootJavaFolder - 1)
+            )
+        )
+
+        // creating the sdkman "current" symlink and pointing to zulu
+        val sdkmanEnvironmentJavaHome = javaDistributionsRootFolderPath.resolve("current")
+            .createSymbolicLinkPointingTo(zuluRootFolderPath.toAbsolutePath())
+        val javaExecutableFolder = javaHomePath.resolve(JAVA_EXECUTABLES_FOLDER).createDirectories()
+
+        // creating zulu bin symlink and pointing it to the actual /Contents/Home/bin folder
+        zuluRootFolderPath.resolve(JAVA_EXECUTABLES_FOLDER)
+            .createSymbolicLinkPointingTo(javaExecutableFolder.toAbsolutePath())
+
+        // environmentJavaHome=***/Users/doctor/.sdkman/candidates/java/current and gradleJavaHome=***/Users/doctor/.sdkman/candidates/java/17.0.10-zulu/zulu-17.jdk/Contents/Home
+        val jvmVariables = JvmVariables(sdkmanEnvironmentJavaHome.pathString, javaHomePath.pathString)
+        underTest = JavaHomeCheck(jvmVariables, allJavaHomeChecksEnabled, pillBoxPrinter, spyPrescriptionsGenerator)
+        underTest.onStart()
+        val errors = underTest.onFinish()
+        assertFalse(spyPrescriptionsGenerator.noJavaHomeGenerationWasCalled)
+        assertFalse(spyPrescriptionsGenerator.javaHomeMismatchGenerationWasCalled)
+        assertTrue(errors.isEmpty())
+    }
+
+    private fun setupJavaHomePathStructure(folders: Array<String>): Path {
+        return Paths.get(testProjectRoot.root.path, *folders).also {
+            it.createDirectories()
+        }
+    }
+
+    private fun setupIdenticalJvmVariables(): JvmVariables {
+        val legitPath = javaHomePath.pathString
+        return JvmVariables(legitPath, legitPath)
+    }
+
+    private fun setupDifferentJvmVariables(): JvmVariables {
+        val anotherJavaHomePath = setupJavaHomePathStructure(anotherLegitJavaHomePathFolders)
+        return JvmVariables(javaHomePath.toString(), anotherJavaHomePath.toString())
+    }
+
+    private fun verifyJvmVariablesAreUsedForPrescriptionGeneration(jvmVariables: JvmVariables) {
+        assertEquals(jvmVariables.environmentJavaHome, spyPrescriptionsGenerator.capturedJavaHomeLocation)
+        assertEquals(jvmVariables.gradleJavaHome, spyPrescriptionsGenerator.capturedGradleJavaHomeLocation)
+    }
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/JavaHomeCheckTest.kt
@@ -36,8 +36,6 @@ class JavaHomeCheckTest {
     val testProjectRoot = TemporaryFolder()
 
     private val javaHomeHandler = mock<JavaHomeHandler>()
-    private val doctorExtension =
-        mock<DoctorExtension>().also { whenever(it.javaHomeHandler).thenReturn(javaHomeHandler) }
     private val alwaysFalseProperty = mock<Property<Boolean>>().also { whenever(it.get()).thenReturn(false) }
     private val alwaysTrueProperty = mock<Property<Boolean>>().also { whenever(it.get()).thenReturn(true) }
     private val errorMessageProperty =
@@ -91,7 +89,7 @@ class JavaHomeCheckTest {
         underTest =
             JavaHomeCheck(
                 jvmVariables,
-                doctorExtension,
+                javaHomeHandler,
                 pillBoxPrinter,
                 spyPrescriptionsGenerator
             )
@@ -107,7 +105,7 @@ class JavaHomeCheckTest {
     fun `given gradle and environment java home path doesn't match when a failOnError check is performed then there is at least one prescription and an exception thrown`() {
         val jvmVariables = setupDifferentJvmVariables()
         whenever(javaHomeHandler.failOnError).thenReturn(alwaysTrueProperty)
-        underTest = JavaHomeCheck(jvmVariables, doctorExtension, pillBoxPrinter, spyPrescriptionsGenerator)
+        underTest = JavaHomeCheck(jvmVariables, javaHomeHandler, pillBoxPrinter, spyPrescriptionsGenerator)
         underTest.onStart()
         assertFalse(spyPrescriptionsGenerator.noJavaHomeGenerationWasCalled)
         assertTrue(spyPrescriptionsGenerator.javaHomeMismatchGenerationWasCalled)
@@ -118,7 +116,7 @@ class JavaHomeCheckTest {
     @Test
     fun `given gradle and environment java home path doesn't match when a full check is performed then there is at least one prescription`() {
         val jvmVariables = setupDifferentJvmVariables()
-        underTest = JavaHomeCheck(jvmVariables, doctorExtension, pillBoxPrinter, spyPrescriptionsGenerator)
+        underTest = JavaHomeCheck(jvmVariables, javaHomeHandler, pillBoxPrinter, spyPrescriptionsGenerator)
         underTest.onStart()
         val errors = underTest.onFinish()
         assertTrue(errors.isNotEmpty())
@@ -130,7 +128,7 @@ class JavaHomeCheckTest {
     @Test
     fun `given gradle and environment java home matches when a full check is performed then there are no prescriptions`() {
         val legitJvmVariables = setupIdenticalJvmVariables()
-        underTest = JavaHomeCheck(legitJvmVariables, doctorExtension, pillBoxPrinter)
+        underTest = JavaHomeCheck(legitJvmVariables, javaHomeHandler, pillBoxPrinter)
         underTest.onStart()
         val errors = underTest.onFinish()
         verifyZeroInteractions(pillBoxPrinter)
@@ -174,7 +172,7 @@ class JavaHomeCheckTest {
 
         // environmentJavaHome=***/Users/doctor/.sdkman/candidates/java/current and gradleJavaHome=***/Users/doctor/.sdkman/candidates/java/17.0.10-zulu/zulu-17.jdk/Contents/Home
         val jvmVariables = JvmVariables(sdkmanEnvironmentJavaHome.pathString, javaHomePath.pathString)
-        underTest = JavaHomeCheck(jvmVariables, doctorExtension, pillBoxPrinter, spyPrescriptionsGenerator)
+        underTest = JavaHomeCheck(jvmVariables, javaHomeHandler, pillBoxPrinter, spyPrescriptionsGenerator)
         underTest.onStart()
         val errors = underTest.onFinish()
         assertFalse(spyPrescriptionsGenerator.noJavaHomeGenerationWasCalled)

--- a/doctor-plugin/src/test/java/com/osacky/doctor/internal/SpyJavaHomePrescriptionsGenerator.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/internal/SpyJavaHomePrescriptionsGenerator.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.osacky.doctor.internal
+
+class SpyJavaHomePrescriptionsGenerator : JavaHomeCheckPrescriptionsGenerator {
+
+    var noJavaHomeGenerationWasCalled = false
+    var javaHomeMismatchGenerationWasCalled = false
+    var capturedJavaHomeLocation: String? = null
+    var capturedGradleJavaHomeLocation: String = ""
+    override fun generateJavaHomeIsNotSetMessage(): String {
+        noJavaHomeGenerationWasCalled = true
+        return "Fake no java home message."
+    }
+
+    override fun generateJavaHomeMismatchesGradleHome(
+        javaHomeLocation: String?,
+        gradleJavaHomeLocation: String
+    ): String {
+        javaHomeMismatchGenerationWasCalled = true
+        capturedJavaHomeLocation = javaHomeLocation
+        capturedGradleJavaHomeLocation = gradleJavaHomeLocation
+        return "Fake java mismatch prescription."
+    }
+}

--- a/doctor-plugin/src/test/java/com/osacky/doctor/internal/SpyJavaHomePrescriptionsGenerator.kt
+++ b/doctor-plugin/src/test/java/com/osacky/doctor/internal/SpyJavaHomePrescriptionsGenerator.kt
@@ -17,11 +17,11 @@
 package com.osacky.doctor.internal
 
 class SpyJavaHomePrescriptionsGenerator : JavaHomeCheckPrescriptionsGenerator {
-
     var noJavaHomeGenerationWasCalled = false
     var javaHomeMismatchGenerationWasCalled = false
     var capturedJavaHomeLocation: String? = null
     var capturedGradleJavaHomeLocation: String = ""
+
     override fun generateJavaHomeIsNotSetMessage(): String {
         noJavaHomeGenerationWasCalled = true
         return "Fake no java home message."
@@ -29,7 +29,7 @@ class SpyJavaHomePrescriptionsGenerator : JavaHomeCheckPrescriptionsGenerator {
 
     override fun generateJavaHomeMismatchesGradleHome(
         javaHomeLocation: String?,
-        gradleJavaHomeLocation: String
+        gradleJavaHomeLocation: String,
     ): String {
         javaHomeMismatchGenerationWasCalled = true
         capturedJavaHomeLocation = javaHomeLocation


### PR DESCRIPTION
Motivation for change - see this [thread](https://github.com/runningcode/gradle-doctor/pull/241#issuecomment-1987283775).
Changes:

- java home check now looks for or tries to resolve **bin** folder(where all executables [reside](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jdkfiles.html) by default) in order to resolve full/real path. It still has a fallback to initial path in case **bin** isn't there
- added `JvmVariables` and `JavaHomeCheckConfig` in order to use them as "injectable" `JavaHomeCheck` constructor params, which slightly improves testability and decoupling. 
- added `JavaHomeCheckPrescriptionsGenerator` and it's default implementation. Same reasoning - better testability and decoupling(nice to have a dedicated abstraction just to delegate the exact message generation).
- added tests for standard flows and one for the zulu+sdkman filesystem structure