### PR TITLE
Fix run apple rosetta translation check

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorPlugin.kt
@@ -86,12 +86,12 @@ class DoctorPlugin : Plugin<Project> {
         buildCacheConnectionMeasurer.onStart()
         buildCacheKey.onStart()
         slowerFromCacheCollector.onStart()
-        appleRosettaTranslationCheck.onStart()
         target.afterEvaluate {
             daemonChecker.onStart()
             javaHomeCheck.onStart()
             javaElevenGC.onStart()
             kotlinCompileDaemonFallbackDetector.onStart()
+            appleRosettaTranslationCheck.onStart()
         }
 
         val buildScanApi = findAdapter(target)


### PR DESCRIPTION
`appleRosettaTranslationCheckMode` is always `ERROR`, because the check runs before the extension is configured.