### PR TITLE
[Discussion] Make plugin project isolation compatible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.osacky.doctor.DoctorExtension
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 // Upgrade transitive dependencies in plugin classpath
@@ -18,20 +17,7 @@ buildscript {
 plugins {
   alias(libs.plugins.kgp)
   alias(libs.plugins.versions)
-//  id("com.osacky.doctor")
 }
-
-//configure<DoctorExtension> {
-//  disallowMultipleDaemons.set(false)
-//  GCWarningThreshold.set(0.01f)
-//  enableTestCaching.set(false)
-//  downloadSpeedWarningThreshold.set(2.0f)
-//  daggerThreshold.set(100)
-//  javaHome {
-//      ensureJavaHomeMatches.set(true)
-//      ensureJavaHomeIsSet.set(true)
-//  }
-//}
 
 tasks.withType(Test::class.java).configureEach {
   testLogging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,20 +18,20 @@ buildscript {
 plugins {
   alias(libs.plugins.kgp)
   alias(libs.plugins.versions)
-  id("com.osacky.doctor")
+//  id("com.osacky.doctor")
 }
 
-configure<DoctorExtension> {
-  disallowMultipleDaemons.set(false)
-  GCWarningThreshold.set(0.01f)
-  enableTestCaching.set(false)
-  downloadSpeedWarningThreshold.set(2.0f)
-  daggerThreshold.set(100)
-  javaHome {
-      ensureJavaHomeMatches.set(true)
-      ensureJavaHomeIsSet.set(true)
-  }
-}
+//configure<DoctorExtension> {
+//  disallowMultipleDaemons.set(false)
+//  GCWarningThreshold.set(0.01f)
+//  enableTestCaching.set(false)
+//  downloadSpeedWarningThreshold.set(2.0f)
+//  daggerThreshold.set(100)
+//  javaHome {
+//      ensureJavaHomeMatches.set(true)
+//      ensureJavaHomeIsSet.set(true)
+//  }
+//}
 
 tasks.withType(Test::class.java).configureEach {
   testLogging {

--- a/doctor-plugin/build.gradle.kts
+++ b/doctor-plugin/build.gradle.kts
@@ -46,7 +46,7 @@ gradlePlugin {
             displayName = "Doctor Plugin"
             description = "The right prescription for your gradle build."
             tags.addAll(listOf("doctor", "android"))
-            implementationClass = "com.osacky.doctor.DoctorPlugin"
+            implementationClass = "com.osacky.doctor.DoctorSettingsPlugin"
         }
     }
 }

--- a/doctor-plugin/src/integrationTest/java/com/osacky/doctor/TestIntegrationTest.kt
+++ b/doctor-plugin/src/integrationTest/java/com/osacky/doctor/TestIntegrationTest.kt
@@ -12,7 +12,9 @@ class TestIntegrationTest {
 
     @Test
     fun testIgnoreOnEmptyDirectories() {
-        testProjectRoot.writeBuildGradle(
+        testProjectRoot.writeBuildGradle("")
+        val fixtureName = "java-fixture"
+        testProjectRoot.newFile("settings.gradle").writeText(
             """
                     |plugins {
                     |  id "com.osacky.doctor"
@@ -25,10 +27,9 @@ class TestIntegrationTest {
                     |  failOnEmptyDirectories = true
                     |  warnWhenNotUsingParallelGC = false
                     |}
-                """.trimMargin("|"),
+                    |include '$fixtureName'
+                """.trimMargin("|")
         )
-        val fixtureName = "java-fixture"
-        testProjectRoot.newFile("settings.gradle").writeText("include '$fixtureName'")
         testProjectRoot.setupFixture(fixtureName)
         testProjectRoot.newFolder("java-fixture", "src", "main", "java", "com", "foo")
 
@@ -46,7 +47,9 @@ class TestIntegrationTest {
 
     @Test
     fun testDirectoriesIgnoredIn6dot8() {
-        testProjectRoot.writeBuildGradle(
+        testProjectRoot.writeBuildGradle("")
+        val fixtureName = "java-fixture"
+        testProjectRoot.newFile("settings.gradle").writeText(
             """
                     |plugins {
                     |  id "com.osacky.doctor"
@@ -59,10 +62,9 @@ class TestIntegrationTest {
                     |  failOnEmptyDirectories = true
                     |  warnWhenNotUsingParallelGC = false
                     |}
-                """.trimMargin("|"),
+                    |include '$fixtureName'
+                """.trimMargin("|")
         )
-        val fixtureName = "java-fixture"
-        testProjectRoot.newFile("settings.gradle").writeText("include '$fixtureName'")
         testProjectRoot.setupFixture(fixtureName)
         testProjectRoot.newFolder("java-fixture", "src", "main", "java", "com", "foo")
 
@@ -135,18 +137,8 @@ class TestIntegrationTest {
         testProjectRoot.writeBuildGradle(
             """
             plugins {
-              id "com.osacky.doctor"
               id 'java-library'
             }
-            doctor {
-              disallowMultipleDaemons = false
-              javaHome {
-                ensureJavaHomeMatches = false
-              }
-              warnWhenNotUsingParallelGC = false
-              disallowCleanTaskDependencies = $disallowCleanTaskDependencies
-            }
-            
             tasks.register('foo') {
               doFirst {
                 println 'foo'
@@ -157,6 +149,22 @@ class TestIntegrationTest {
               dependsOn 'foo'
             }
             """.trimIndent(),
+        )
+
+        testProjectRoot.newFile("settings.gradle").writeText(
+            """
+            plugins {
+              id "com.osacky.doctor"
+            }
+            doctor {
+              disallowMultipleDaemons = false
+              javaHome {
+                ensureJavaHomeMatches = false
+              }
+              warnWhenNotUsingParallelGC = false
+              disallowCleanTaskDependencies = $disallowCleanTaskDependencies
+            }
+            """.trimIndent()
         )
     }
 }

--- a/doctor-plugin/src/main/java/com/osacky/doctor/AppProjectCollectorBuildService.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/AppProjectCollectorBuildService.kt
@@ -1,0 +1,25 @@
+package com.osacky.doctor
+
+import org.gradle.api.Project
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+abstract class AppProjectCollectorBuildService : BuildService<BuildServiceParameters.None> {
+    private val appProjects = mutableSetOf<Project>()
+
+    fun addProject(project: Project) {
+        appProjects.add(project)
+    }
+
+    fun getProjects(): Set<Project> {
+        return appProjects
+    }
+}
+
+fun Project.getAppProjectCollectorBuildService(): AppProjectCollectorBuildService {
+    return project.gradle.sharedServices.registerIfAbsent(
+        "appProjectCollector",
+        AppProjectCollectorBuildService::class.java,
+        {}
+    ).get()
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorChildModulePlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorChildModulePlugin.kt
@@ -1,0 +1,48 @@
+package com.osacky.doctor
+
+import com.osacky.doctor.internal.farthestEmptyParent
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.testing.Test
+import org.gradle.util.GradleVersion
+
+class DoctorChildModulePlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        val extension = target.getDoctorExtension()
+        target.tasks.withType(SourceTask::class.java).configureEach {
+            if (!gradleIgnoresEmptyDirectories() && extension.failOnEmptyDirectories.get()) {
+                // Fail build if empty directories are found. These cause build cache misses and should be ignored by Gradle.
+                doFirst {
+                    source.visit {
+                        if (file.isDirectory && file.listFiles().isEmpty()) {
+                            val farthestEmptyParent = file.farthestEmptyParent()
+                            throw IllegalStateException(
+                                "Empty src dir(s) found. This causes build cache misses. Run the following command to fix it.\n" +
+                                        "rmdir ${farthestEmptyParent.absolutePath}",
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        // Ensure we are not caching any test tasks. Tests may not declare all inputs properly or depend on things like the date and caching them can lead to dangerous false positives.
+        target.tasks.withType(Test::class.java).configureEach {
+            if (!extension.enableTestCaching.get()) {
+                outputs.upToDateWhen { false }
+            }
+        }
+        target.plugins.whenPluginAdded plugin@{
+            if (this.javaClass.name == "com.android.build.gradle.AppPlugin") {
+                target.getAppProjectCollectorBuildService().addProject(target)
+            }
+        }
+    }
+
+    /**
+     * Gradle now ignores empty directories starting in 6.8
+     * https://docs.gradle.org/6.8-rc-1/release-notes.html#performance-improvements
+     **/
+    private fun gradleIgnoresEmptyDirectories(): Boolean = GradleVersion.current() >= GradleVersion.version("6.8-rc-1")
+
+}

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorExtension.kt
@@ -2,7 +2,10 @@ package com.osacky.doctor
 
 import com.osacky.doctor.AppleRosettaTranslationCheckMode.ERROR
 import org.gradle.api.Action
+import org.gradle.api.GradleException
+import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
@@ -100,6 +103,16 @@ open class DoctorExtension(
     fun javaHome(action: Action<JavaHomeHandler>) {
         action.execute(javaHomeHandler)
     }
+
+    companion object {
+        const val EXTRAS_KEY = "_doctorExtension_settings"
+    }
+}
+
+fun Project.getDoctorExtension(): DoctorExtension {
+    val defaults = extensions.getByType(ExtraPropertiesExtension::class.java).get(DoctorExtension.EXTRAS_KEY)
+            as? DoctorExtension ?: throw GradleException("Settings extension type mismatch")
+    return defaults
 }
 
 abstract class JavaHomeHandler

--- a/doctor-plugin/src/main/java/com/osacky/doctor/DoctorSettingsPlugin.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/DoctorSettingsPlugin.kt
@@ -1,0 +1,23 @@
+package com.osacky.doctor
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.kotlin.dsl.create
+
+class DoctorSettingsPlugin : Plugin<Settings> {
+    override fun apply(target: Settings) {
+
+        val extension = target.extensions.create<DoctorExtension>("doctor")
+        target.gradle.beforeProject {
+            extensions.getByType(ExtraPropertiesExtension::class.java)
+                .set(DoctorExtension.EXTRAS_KEY, extension)
+
+            if (this.parent == null) {
+                plugins.apply(DoctorPlugin::class.java)
+            } else {
+                plugins.apply(DoctorChildModulePlugin::class.java)
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,18 +1,34 @@
+import com.osacky.doctor.DoctorExtension
+
 pluginManagement {
   repositories {
     mavenCentral()
     gradlePluginPortal()
   }
+  includeBuild("doctor-plugin")
 }
 
 plugins {
   id("com.gradle.develocity") version "3.18.1"
+  id("com.osacky.doctor")
 }
 
 develocity {
   buildScan {
     termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
     termsOfUseAgree = "yes"
+  }
+}
+
+configure<DoctorExtension> {
+  disallowMultipleDaemons.set(false)
+  GCWarningThreshold.set(0.01f)
+  enableTestCaching.set(false)
+  downloadSpeedWarningThreshold.set(2.0f)
+  daggerThreshold.set(100)
+  javaHome {
+    ensureJavaHomeMatches.set(true)
+    ensureJavaHomeIsSet.set(true)
   }
 }
 


### PR DESCRIPTION
I want to use this PR has a starting point to discuss making this plugin Project Isolation compatible and solving #302.

I believe what I have right now to be the minimal amount of changes needed to support project isolation. Before I commit to further work on this, I wanted to get some feedback on the approach here.

Main changes:

* `DoctorPlugin` is now broken up into 3 plugins: a settings plugin `DoctorSettingsPlugin`, a root project plugin `DoctorPlugin`, and a module plugin `DoctorChildModulePlugin` 
* `com.osacky.doctor` now points to the settings plugin class and must be applied in settings.gradle
* The extension is configured in settings.gradle and shared to all project following [this pattern](https://www.liutikas.net/2024/10/28/DRY-Gradle-Configuration-Values.html)
* Child modules use a build service to register back to the root project if the Android app plugin gets applied in order to support the `allowBuildingAllAndroidAppsSimultaneously` settings. Though I'm not sure how useful this actually is


From my testing on our large 900+ module project it seems to work as before and no longer violates project isolation. I have not tested if there are any differences in performance.

