### PR TITLE
Update Android Studio/IntelliJ location of where Gradle JDK is set

### DIFF
--- a/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
+++ b/doctor-plugin/src/main/java/com/osacky/doctor/internal/JavaHomeCheckPrescriptionsGenerator.kt
@@ -33,7 +33,7 @@ internal const val JAVA_HOME_DOESNT_MATCH_GRADLE_HOME = """
     %s
     %s
     This can slow down your build significantly when switching from Android Studio or IntelliJ to the terminal.
-    To fix: Project Structure -> JDK Location.
+    To fix: Settings -> Build, Execution, Deployment -> Build Tools -> Gradle -> Gradle JDK.
     Set this to your JAVA_HOME.
     %s
 """


### PR DESCRIPTION
The `Project Structure > JDK Location` no longer exists, so can be quite confusing if one hits this error message, hoping to following the recommended fix. Since this line hasn't been updated since 2019 (https://github.com/runningcode/gradle-doctor/commit/c0145836b5cc873be67f8ac4a7b2cd7d9f957cc3), I'm assuming that this advice was valid for the Android Studio/IntelliJs of the time, but it has since changed.

The location was obtained by looking at where this setting is in my local installation of Android Studio (2024.3.2), but there is public documentation surrounding it's location [here](https://www.jetbrains.com/help/idea/gradle-jvm-selection.html#jvm_settings).

<img alt="Screenshot 2025-05-09 at 12 16 07" src="https://github.com/user-attachments/assets/46139aa8-c2ef-4935-a534-f2fe024c6794" />