### PR TITLE
build(deps): Move dagger-kapt dependencies to the version catalog

### DIFF
--- a/dagger-kapt/build.gradle.kts
+++ b/dagger-kapt/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 
 dependencies {
   implementation(libs.kotlin.stdlib)
-  implementation("com.google.dagger:dagger:2.59.2")
-  kapt("com.google.dagger:dagger-compiler:2.59.2")
+  implementation(libs.dagger)
+  kapt(libs.dagger.compiler)
 
-  implementation("com.google.auto.value:auto-value-annotations:1.11.1")
-  kapt("com.google.auto.value:auto-value:1.11.1")
+  implementation(libs.auto.value.annotations)
+  kapt(libs.auto.value)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 kotlin = "2.2.21"
 junit = "4.13.2"
+dagger = "2.59.2"
+auto-value = "1.11.1"
 
 [libraries]
 junit = { module = "junit:junit", version.ref = "junit" }
@@ -10,11 +12,15 @@ rxjava = "io.reactivex.rxjava3:rxjava:3.1.12"
 mockito = "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
 develocity-agent-adapters = "com.gradle:develocity-gradle-plugin-adapters:1.2.1"
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
+dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
+auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
+auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }
 
 [plugins]
 kgp = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 versions = { id = "com.github.ben-manes.versions", version = "0.61.0" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "5.2.0" }
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.1" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.35.0" }
-


### PR DESCRIPTION
The `dagger` and `auto-value` coordinates in `dagger-kapt/build.gradle.kts` were the last hardcoded dependencies in the build. Everything else already resolved through `gradle/libs.versions.toml`, including the `doctor-plugin` included build, which shares the same catalog file.

- Added `dagger` and `auto-value` version refs and their four library entries to the catalog
- Added a `kapt` plugin alias sharing the existing `kotlin` version ref
- Switched `dagger-kapt` to the catalog accessors

Resolved versions are unchanged.

### Left alone

- **`settings.gradle.kts` plugins** (`com.gradle.develocity`, `common-custom-user-data`) — the catalog isn't available inside a settings script's `plugins {}` block, since it's built during settings evaluation. These have to stay literal.
- **Test-resource fixtures** under `doctor-plugin/src/*/resources/` — standalone builds run by TestKit with intentionally pinned versions (e.g. dagger 2.25.4 to exercise the old-dagger warning), not part of this build's dependency graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)